### PR TITLE
[MGDOBR-393]: Configure i18n and setup default EN locale dictionary

### DIFF
--- a/locales/en/openbridge.json
+++ b/locales/en/openbridge.json
@@ -1,0 +1,3 @@
+{
+  "demoOverview": "Demo Overview"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "4.164.2",
-        "@patternfly/react-core": "4.157.3",
-        "@patternfly/react-icons": "4.11.17",
-        "@patternfly/react-styles": "4.11.16",
-        "@patternfly/react-table": "4.30.3",
-        "@rhoas/app-services-ui-shared": "^0.15.4",
+        "@patternfly/react-core": "4.181.1",
+        "@patternfly/react-icons": "4.32.1",
+        "@patternfly/react-styles": "4.31.1",
+        "@patternfly/react-table": "4.50.1",
+        "@rhoas/app-services-ui-components": "1.11.8",
+        "@rhoas/app-services-ui-shared": "0.15.4",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "react-i18next": "^11.14.3",
+        "react-i18next": "11.14.3",
         "react-router-dom": "5.2.1"
       },
       "devDependencies": {
@@ -628,14 +629,45 @@
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.164.2.tgz",
       "integrity": "sha512-gezQi83JKd6tW0z1J6Q5VvMCW/a58+ys4TWcTuXUMqcV3APQdNxVP+ZV6FIv5353oIPi9HuWAaApVwcCxYZYYg=="
     },
-    "node_modules/@patternfly/react-core": {
-      "version": "4.157.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.157.3.tgz",
-      "integrity": "sha512-vP4/lZLTy0U4jmVP7ZO8I7EX1qSyVyFFbay01Pj1pVGHo74gP7yaUFwMvAvURGYmNeWdAhxgIBfYV8VimkSwLg==",
+    "node_modules/@patternfly/react-charts": {
+      "version": "6.34.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.34.1.tgz",
+      "integrity": "sha512-KcPf4zZGABzeqXMOzIIl/CWCf/St70EM8QKUnWdxAz8z3ZbSNvPQtUl0XuGqCoR7KBI74FJ6RnWEYtsExh9gvA==",
       "dependencies": {
-        "@patternfly/react-icons": "^4.11.17",
-        "@patternfly/react-styles": "^4.11.16",
-        "@patternfly/react-tokens": "^4.12.18",
+        "@patternfly/react-styles": "^4.31.1",
+        "@patternfly/react-tokens": "^4.33.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.19",
+        "tslib": "^2.0.0",
+        "victory-area": "^35.9.0",
+        "victory-axis": "^35.9.0",
+        "victory-bar": "^35.9.0",
+        "victory-chart": "^35.9.0",
+        "victory-core": "^35.9.0",
+        "victory-create-container": "^35.9.1",
+        "victory-group": "^35.9.0",
+        "victory-legend": "^35.9.0",
+        "victory-line": "^35.9.0",
+        "victory-pie": "^35.9.0",
+        "victory-scatter": "^35.9.0",
+        "victory-stack": "^35.9.0",
+        "victory-tooltip": "^35.9.1",
+        "victory-voronoi-container": "^35.9.1",
+        "victory-zoom-container": "^35.9.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@patternfly/react-core": {
+      "version": "4.181.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.181.1.tgz",
+      "integrity": "sha512-5pt4R8Cg8CkA6xCY4v6wurpwn8WIS8N8NqQEtp56WABMVpZC+TE7k1TSsrDDR1WhJlxsl48VbsANkwMYLlsSJg==",
+      "dependencies": {
+        "@patternfly/react-icons": "^4.32.1",
+        "@patternfly/react-styles": "^4.31.1",
+        "@patternfly/react-tokens": "^4.33.1",
         "focus-trap": "6.2.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -647,28 +679,28 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "4.11.17",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.11.17.tgz",
-      "integrity": "sha512-T6HriEy2SgVxlQxPL0FTHQqBYdPbaMeEiK4CzIAPQvCuCT3kRUEEGNyG+VVEvc+XU8ndSiTJdOkHaq08onFvsg==",
+      "version": "4.32.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.32.1.tgz",
+      "integrity": "sha512-E7Fpnvax37e2ow8Xc2GngQBM7IuOpRyphZXCIUAk/NGsqpvFX27YhIVZiOUIAuBXAI5VXQBwueW/tmhmlXP7+w==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "4.11.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.11.16.tgz",
-      "integrity": "sha512-4ZFynQuJmRF7VbZeQSs44MX6MEvW7l7ZR8lMeChd8mxnQpG8pWtVUbcHdj9FFHPZVa+sPrgrZQl8QmhbqYyOsg=="
+      "version": "4.31.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.31.1.tgz",
+      "integrity": "sha512-Yw2hgg3T2qEqPYej5xprYD0iTTkzFMNjaF8u/YFyZOBNwfhjK8QQDZx8Du7Z6em8zGtajXFG5rZqxDiiz8bDfQ=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "4.30.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.30.3.tgz",
-      "integrity": "sha512-qjaXN3iJQdV6XPfv7TTK/zF6pt8IKreJOJy5k+FfFqYJfO32/04BTS1OnKGU8QM0AKl8bKyzQ6RGoXXxyMZBQQ==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.50.1.tgz",
+      "integrity": "sha512-8/vYbp1ryARu/ZOuMgZQzV0lRiq1whUq4s6R7lW1O/UZf73geGoIODag7zn2CD9tddHTDWfck1xo6bMn6fjn5w==",
       "dependencies": {
-        "@patternfly/react-core": "^4.157.3",
-        "@patternfly/react-icons": "^4.11.17",
-        "@patternfly/react-styles": "^4.11.16",
-        "@patternfly/react-tokens": "^4.12.18",
+        "@patternfly/react-core": "^4.181.1",
+        "@patternfly/react-icons": "^4.32.1",
+        "@patternfly/react-styles": "^4.31.1",
+        "@patternfly/react-tokens": "^4.33.1",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       },
@@ -1160,6 +1192,62 @@
       "dependencies": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/@rhoas/app-services-ui-components": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@rhoas/app-services-ui-components/-/app-services-ui-components-1.11.8.tgz",
+      "integrity": "sha512-Az/9eB/rPVYOa0YS4jQcLTrSAHz5czo6bRrLyDyl334Tqxb7Cs/C/uVg+zQQGB3+uyDz88mR2g7es2qN1D/TzA==",
+      "dependencies": {
+        "@patternfly/react-charts": "6.34.1",
+        "@xstate/react": "1.6.3",
+        "byte-size": "8.1.0",
+        "date-fns": "2.28.0",
+        "date-fns-tz": "1.2.2",
+        "i18next": "21.6.6",
+        "react-i18next": "11.15.3",
+        "tslib": "2.3.1",
+        "xstate": "4.27.0"
+      },
+      "peerDependencies": {
+        "@patternfly/patternfly": "4.164.2",
+        "@patternfly/react-core": "4.181.1",
+        "@patternfly/react-icons": "4.32.1",
+        "@patternfly/react-table": "4.50.1",
+        "@rhoas/app-services-ui-shared": "0.15.4",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "react-router-dom": "5.2.1"
+      }
+    },
+    "node_modules/@rhoas/app-services-ui-components/node_modules/i18next": {
+      "version": "21.6.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.6.tgz",
+      "integrity": "sha512-K1Pw8K+nHVco56PO6UrqNq4K/ZVbb2eqBQwPqmzYDm4tGQYXBjdz8jrnvuNvV5STaE8oGpWKQMxHOvh2zhVE7Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0"
+      }
+    },
+    "node_modules/@rhoas/app-services-ui-components/node_modules/react-i18next": {
+      "version": "11.15.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.15.3.tgz",
+      "integrity": "sha512-RSUEM4So3Tu2JHV0JsZ5Yje+4nz66YViMfPZoywxOy0xyn3L7tE2CHvJ7Y9LUsrTU7vGmZ5bwb8PpjnkatdIxg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.5",
+        "html-escaper": "^2.0.2",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 19.0.0",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rhoas/app-services-ui-shared": {
@@ -1989,6 +2077,28 @@
         }
       }
     },
+    "node_modules/@xstate/react": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-1.6.3.tgz",
+      "integrity": "sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.0.0",
+        "use-subscription": "^1.3.0"
+      },
+      "peerDependencies": {
+        "@xstate/fsm": "^1.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "xstate": "^4.11.0"
+      },
+      "peerDependenciesMeta": {
+        "@xstate/fsm": {
+          "optional": true
+        },
+        "xstate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -2657,6 +2767,14 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/byte-size": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.0.tgz",
+      "integrity": "sha512-FkgMTAg44I0JtEaUAvuZTtU2a2YDmBRbQxdsQNSMtLCjhG0hMcF5b1IMN9UjSCJaU4nvlj/GER7B9sI4nKdCgA==",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/bytes": {
@@ -3625,6 +3743,84 @@
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
       "dev": true
     },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3635,13 +3831,20 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "dev": true,
       "engines": {
         "node": ">=0.11"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.2.2.tgz",
+      "integrity": "sha512-vWtn44eEqnLbkACb7T5G5gPgKR4nY8NkNMOCyoY49NsRGHrcDmY2aysCyzDeA+u+vcDBn/w6nQqEDyouRs4m8w==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -3779,6 +3982,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "node_modules/delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "dependencies": {
+        "delaunator": "^4.0.0"
       }
     },
     "node_modules/depd": {
@@ -5522,6 +5738,11 @@
       "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
       "dev": true
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+    },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -5714,9 +5935,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "21.6.11",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.11.tgz",
-      "integrity": "sha512-tJ2+o0lVO+fhi8bPkCpBAeY1SgkqmQm5NzgPWCQssBrywJw98/o+Kombhty5nxQOpHtvMmsxcOopczUiH6bJxQ==",
+      "version": "21.6.13",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.13.tgz",
+      "integrity": "sha512-MVjNttw+5mIuu2/fwTpSU0EeI7iU/6pnDvGQboCzkILiv0/gD+FLZaF7qSHmUHO4ZkE6xJQ9SlBgGvMHxhC82Q==",
       "funding": [
         {
           "type": "individual",
@@ -6476,6 +6697,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -8486,6 +8712,11 @@
         "react": ">=0.14.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "node_modules/react-i18next": {
       "version": "11.14.3",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.14.3.tgz",
@@ -10064,6 +10295,30 @@
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-subscription": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
+      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
+      "dependencies": {
+        "object-assign": "^4.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
@@ -10126,6 +10381,293 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-area": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.11.4.tgz",
+      "integrity": "sha512-i3rN4Jvn1uwA3YvCuv3EIPEcK2SWSOq3c+TvLvVj1BKFQug11C06UjyQje+3EEzffZ/EMkvGqj2+YudIjrGEzA==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-axis": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.11.4.tgz",
+      "integrity": "sha512-KmPXC/vgbiiWckhK0LruZvsFQqESg6BflhIqS/Xemc50ymWetqbT9VZhjPWbU0arOIP5E8xcFnGUimDN//Jffw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-bar": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.11.4.tgz",
+      "integrity": "sha512-EZC+6VGwHkIcOYEppVFBIC5JymYnfF+RLF+NM0Uys7q5+AwaLx36LS9a2xBUBYO/gx20Wd1HVH8kjSHzw1rTqQ==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-brush-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.11.4.tgz",
+      "integrity": "sha512-KpFYU2LxKbLIjZDhXTdveok1SWLFlG5s2R214IRq+ukYRz21CoxlvZCWhFL60lSPilD+ZD1Udv3sK/RW9CFMxA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-chart": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.11.4.tgz",
+      "integrity": "sha512-oBTjx6ytp+/s6zswCuOUQotiISePQKuDUdOsjnbINBPSNvJuE2W9GXHD+B7ibDkCh4ZWXm8obHz7mnrRGbCGFQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^35.11.4",
+        "victory-core": "^35.11.4",
+        "victory-polar-axis": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-core": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.11.4.tgz",
+      "integrity": "sha512-PuqrOIn/a6GQgsp/DKvACiJBAJo71P77jltn56mlDZjAAzz+58BL4E0hx7x908GdodLXo2n9gEeuDdjOAlOt0Q==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-create-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.11.4.tgz",
+      "integrity": "sha512-baDLO4GSk/7eTVEYkhikwgwV5BtrSMuNPjKZBjZrIA3Ka9Fn5shklRG9PWg+26JIBFxqZdM6zOvpF7xhjxi37Q==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^35.11.4",
+        "victory-core": "^35.11.4",
+        "victory-cursor-container": "^35.11.4",
+        "victory-selection-container": "^35.11.4",
+        "victory-voronoi-container": "^35.11.4",
+        "victory-zoom-container": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-cursor-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.11.4.tgz",
+      "integrity": "sha512-gs6bwRd/qbGTN78w2QgshIFxlyOsss5qWOMdCcY9i0Oi99l9OJ6UFQDBzSgKsgD53KGs7JxiKevmUqc3qSZZBg==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-group": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.11.4.tgz",
+      "integrity": "sha512-ceFBll9h1sPpdMjNcvdgEhnYELVHfx9ymmk8iMEjOKpxa4fVvapMhegPmL0/zTemJ/NCu71W2xIr0VqyqK0DaA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-legend": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.11.4.tgz",
+      "integrity": "sha512-JZzQARjxYorWlNf9RmZRPAzlgPjukiUV1aTBaeC8YA2S4PhP4PWhNwO/Pb3aCdkifpumpgsm3JULpJiCGOPdBQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-line": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.11.4.tgz",
+      "integrity": "sha512-uKX6/1b1OmlqJZOsVDCCDlyc9QItgb39vRssTwP4CJX1NLU4Sfgq2i4VVUbHXCo/I2sMEczjf3cdnxdZtC6IFA==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-pie": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.11.4.tgz",
+      "integrity": "sha512-EruxP3PIkrTPTzsC5YhiRKg2s+0UtaRU1ZHZUWK8qi+zlbMDFKYg2AlHqsEnctu5AOdOWLLiye6qUG3oxjiURg==",
+      "dependencies": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-polar-axis": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.11.4.tgz",
+      "integrity": "sha512-mnIRpfARn36TG6ZdCgKR+oWY+pIX6wLHYS0un5xM1TTObKk4IyAR3dnQhEp+3KM1SGoLg0mENFR1Ac8xrus6nQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-scatter": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.11.4.tgz",
+      "integrity": "sha512-8n9rmXmVju2SqA6Xd90rRTmboaU7WStOnj1QUg4q96DDiAVf6kGPdolzCwbUBbiECLyluGoFNJ043WLXztGpiA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-selection-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.11.4.tgz",
+      "integrity": "sha512-Olxnjp9tvHUHeFr4zU/K1dzp0zbeqQRMr2Qqpr85Dd4pWV9bIReE/DanxGhjNg9s3KB5Vsn1GC46PXSTMM1XIQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-shared-events": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+      "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-stack": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.11.4.tgz",
+      "integrity": "sha512-fNTY50fN+DCHcK/9AgMUEq0uJ8IXGnMlRtkSCzMB9ZpEzB7Edx3jLM2Gl970zOkwVaDYXTlikPd1dwf+h3m0dA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-tooltip": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.11.4.tgz",
+      "integrity": "sha512-B+UUqzryurtMghJGiE34tg5eI44vHxyOOcuPIM3IpJLujnNIJXVykBjgQZnFq1CT/63TtDCOlzPkOjSbecPtXQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-voronoi-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.11.4.tgz",
+      "integrity": "sha512-vmwHBm/+nZ9qdRcaNd7r08AVRkus/ER6UA4KAYWkKUe50ZT9NYjDxy0wW/Y7PHQldfL9q/VxAyIE/M6jSFWkEA==",
+      "dependencies": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-tooltip": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-zoom-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.11.4.tgz",
+      "integrity": "sha512-8D4hTdvGZqyZdgWjkz/pDRVy/kijWhptFbK0KWl5J1Tt4YuCGiRC9oxQOpEjlqr8TSyeVnpyuF4QuIp9YOIrAw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
       }
     },
     "node_modules/void-elements": {
@@ -10876,6 +11418,15 @@
         }
       }
     },
+    "node_modules/xstate": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.27.0.tgz",
+      "integrity": "sha512-ohOwDM9tViC/zSSmY9261CHblDPqiaAk5vyjVbi69uJv9fGWMzlm0VDQwM2OvC61GKfXVBeuWSMkL7LPUsTpfA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -11379,14 +11930,41 @@
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.164.2.tgz",
       "integrity": "sha512-gezQi83JKd6tW0z1J6Q5VvMCW/a58+ys4TWcTuXUMqcV3APQdNxVP+ZV6FIv5353oIPi9HuWAaApVwcCxYZYYg=="
     },
-    "@patternfly/react-core": {
-      "version": "4.157.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.157.3.tgz",
-      "integrity": "sha512-vP4/lZLTy0U4jmVP7ZO8I7EX1qSyVyFFbay01Pj1pVGHo74gP7yaUFwMvAvURGYmNeWdAhxgIBfYV8VimkSwLg==",
+    "@patternfly/react-charts": {
+      "version": "6.34.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.34.1.tgz",
+      "integrity": "sha512-KcPf4zZGABzeqXMOzIIl/CWCf/St70EM8QKUnWdxAz8z3ZbSNvPQtUl0XuGqCoR7KBI74FJ6RnWEYtsExh9gvA==",
       "requires": {
-        "@patternfly/react-icons": "^4.11.17",
-        "@patternfly/react-styles": "^4.11.16",
-        "@patternfly/react-tokens": "^4.12.18",
+        "@patternfly/react-styles": "^4.31.1",
+        "@patternfly/react-tokens": "^4.33.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.19",
+        "tslib": "^2.0.0",
+        "victory-area": "^35.9.0",
+        "victory-axis": "^35.9.0",
+        "victory-bar": "^35.9.0",
+        "victory-chart": "^35.9.0",
+        "victory-core": "^35.9.0",
+        "victory-create-container": "^35.9.1",
+        "victory-group": "^35.9.0",
+        "victory-legend": "^35.9.0",
+        "victory-line": "^35.9.0",
+        "victory-pie": "^35.9.0",
+        "victory-scatter": "^35.9.0",
+        "victory-stack": "^35.9.0",
+        "victory-tooltip": "^35.9.1",
+        "victory-voronoi-container": "^35.9.1",
+        "victory-zoom-container": "^35.9.0"
+      }
+    },
+    "@patternfly/react-core": {
+      "version": "4.181.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.181.1.tgz",
+      "integrity": "sha512-5pt4R8Cg8CkA6xCY4v6wurpwn8WIS8N8NqQEtp56WABMVpZC+TE7k1TSsrDDR1WhJlxsl48VbsANkwMYLlsSJg==",
+      "requires": {
+        "@patternfly/react-icons": "^4.32.1",
+        "@patternfly/react-styles": "^4.31.1",
+        "@patternfly/react-tokens": "^4.33.1",
         "focus-trap": "6.2.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -11394,25 +11972,25 @@
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.11.17",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.11.17.tgz",
-      "integrity": "sha512-T6HriEy2SgVxlQxPL0FTHQqBYdPbaMeEiK4CzIAPQvCuCT3kRUEEGNyG+VVEvc+XU8ndSiTJdOkHaq08onFvsg==",
+      "version": "4.32.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.32.1.tgz",
+      "integrity": "sha512-E7Fpnvax37e2ow8Xc2GngQBM7IuOpRyphZXCIUAk/NGsqpvFX27YhIVZiOUIAuBXAI5VXQBwueW/tmhmlXP7+w==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.11.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.11.16.tgz",
-      "integrity": "sha512-4ZFynQuJmRF7VbZeQSs44MX6MEvW7l7ZR8lMeChd8mxnQpG8pWtVUbcHdj9FFHPZVa+sPrgrZQl8QmhbqYyOsg=="
+      "version": "4.31.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.31.1.tgz",
+      "integrity": "sha512-Yw2hgg3T2qEqPYej5xprYD0iTTkzFMNjaF8u/YFyZOBNwfhjK8QQDZx8Du7Z6em8zGtajXFG5rZqxDiiz8bDfQ=="
     },
     "@patternfly/react-table": {
-      "version": "4.30.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.30.3.tgz",
-      "integrity": "sha512-qjaXN3iJQdV6XPfv7TTK/zF6pt8IKreJOJy5k+FfFqYJfO32/04BTS1OnKGU8QM0AKl8bKyzQ6RGoXXxyMZBQQ==",
+      "version": "4.50.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.50.1.tgz",
+      "integrity": "sha512-8/vYbp1ryARu/ZOuMgZQzV0lRiq1whUq4s6R7lW1O/UZf73geGoIODag7zn2CD9tddHTDWfck1xo6bMn6fjn5w==",
       "requires": {
-        "@patternfly/react-core": "^4.157.3",
-        "@patternfly/react-icons": "^4.11.17",
-        "@patternfly/react-styles": "^4.11.16",
-        "@patternfly/react-tokens": "^4.12.18",
+        "@patternfly/react-core": "^4.181.1",
+        "@patternfly/react-icons": "^4.32.1",
+        "@patternfly/react-styles": "^4.31.1",
+        "@patternfly/react-tokens": "^4.33.1",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       }
@@ -11742,6 +12320,42 @@
       "integrity": "sha512-8fjp5l0/RiPWwHLldZnHM8ARrVYP/iYk8XscmE6YhNgDFG9C+Up0pJWXGsV3YeWwppwqR/NtGvdMufoEhy7e7Q==",
       "dev": true,
       "requires": {}
+    },
+    "@rhoas/app-services-ui-components": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@rhoas/app-services-ui-components/-/app-services-ui-components-1.11.8.tgz",
+      "integrity": "sha512-Az/9eB/rPVYOa0YS4jQcLTrSAHz5czo6bRrLyDyl334Tqxb7Cs/C/uVg+zQQGB3+uyDz88mR2g7es2qN1D/TzA==",
+      "requires": {
+        "@patternfly/react-charts": "6.34.1",
+        "@xstate/react": "1.6.3",
+        "byte-size": "8.1.0",
+        "date-fns": "2.28.0",
+        "date-fns-tz": "1.2.2",
+        "i18next": "21.6.6",
+        "react-i18next": "11.15.3",
+        "tslib": "2.3.1",
+        "xstate": "4.27.0"
+      },
+      "dependencies": {
+        "i18next": {
+          "version": "21.6.6",
+          "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.6.tgz",
+          "integrity": "sha512-K1Pw8K+nHVco56PO6UrqNq4K/ZVbb2eqBQwPqmzYDm4tGQYXBjdz8jrnvuNvV5STaE8oGpWKQMxHOvh2zhVE7Q==",
+          "requires": {
+            "@babel/runtime": "^7.12.0"
+          }
+        },
+        "react-i18next": {
+          "version": "11.15.3",
+          "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.15.3.tgz",
+          "integrity": "sha512-RSUEM4So3Tu2JHV0JsZ5Yje+4nz66YViMfPZoywxOy0xyn3L7tE2CHvJ7Y9LUsrTU7vGmZ5bwb8PpjnkatdIxg==",
+          "requires": {
+            "@babel/runtime": "^7.14.5",
+            "html-escaper": "^2.0.2",
+            "html-parse-stringify": "^3.0.1"
+          }
+        }
+      }
     },
     "@rhoas/app-services-ui-shared": {
       "version": "0.15.4",
@@ -12436,6 +13050,15 @@
       "dev": true,
       "requires": {}
     },
+    "@xstate/react": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-1.6.3.tgz",
+      "integrity": "sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0",
+        "use-subscription": "^1.3.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -12933,6 +13556,11 @@
       "requires": {
         "loader-utils": "^1.1.0"
       }
+    },
+    "byte-size": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.0.tgz",
+      "integrity": "sha512-FkgMTAg44I0JtEaUAvuZTtU2a2YDmBRbQxdsQNSMtLCjhG0hMcF5b1IMN9UjSCJaU4nvlj/GER7B9sI4nKdCgA=="
     },
     "bytes": {
       "version": "3.1.1",
@@ -13635,6 +14263,84 @@
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
       "dev": true
     },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -13644,8 +14350,13 @@
     "date-fns": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "dev": true
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
+    "date-fns-tz": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.2.2.tgz",
+      "integrity": "sha512-vWtn44eEqnLbkACb7T5G5gPgKR4nY8NkNMOCyoY49NsRGHrcDmY2aysCyzDeA+u+vcDBn/w6nQqEDyouRs4m8w==",
+      "requires": {}
     },
     "debug": {
       "version": "4.3.3",
@@ -13754,6 +14465,19 @@
             }
           }
         }
+      }
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "requires": {
+        "delaunator": "^4.0.0"
       }
     },
     "depd": {
@@ -15098,6 +15822,11 @@
       "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
       "dev": true
     },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+    },
     "html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -15238,9 +15967,9 @@
       "dev": true
     },
     "i18next": {
-      "version": "21.6.11",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.11.tgz",
-      "integrity": "sha512-tJ2+o0lVO+fhi8bPkCpBAeY1SgkqmQm5NzgPWCQssBrywJw98/o+Kombhty5nxQOpHtvMmsxcOopczUiH6bJxQ==",
+      "version": "21.6.13",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.13.tgz",
+      "integrity": "sha512-MVjNttw+5mIuu2/fwTpSU0EeI7iU/6pnDvGQboCzkILiv0/gD+FLZaF7qSHmUHO4ZkE6xJQ9SlBgGvMHxhC82Q==",
       "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.0"
@@ -15754,6 +16483,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -17194,6 +17928,11 @@
         "prop-types-extra": "^1.1.0"
       }
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "react-i18next": {
       "version": "11.14.3",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.14.3.tgz",
@@ -18391,6 +19130,20 @@
         }
       }
     },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
+      "requires": {}
+    },
+    "use-subscription": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
+      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
+    },
     "util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
@@ -18445,6 +19198,233 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
+    },
+    "victory-area": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.11.4.tgz",
+      "integrity": "sha512-i3rN4Jvn1uwA3YvCuv3EIPEcK2SWSOq3c+TvLvVj1BKFQug11C06UjyQje+3EEzffZ/EMkvGqj2+YudIjrGEzA==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-axis": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.11.4.tgz",
+      "integrity": "sha512-KmPXC/vgbiiWckhK0LruZvsFQqESg6BflhIqS/Xemc50ymWetqbT9VZhjPWbU0arOIP5E8xcFnGUimDN//Jffw==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-bar": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.11.4.tgz",
+      "integrity": "sha512-EZC+6VGwHkIcOYEppVFBIC5JymYnfF+RLF+NM0Uys7q5+AwaLx36LS9a2xBUBYO/gx20Wd1HVH8kjSHzw1rTqQ==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-brush-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.11.4.tgz",
+      "integrity": "sha512-KpFYU2LxKbLIjZDhXTdveok1SWLFlG5s2R214IRq+ukYRz21CoxlvZCWhFL60lSPilD+ZD1Udv3sK/RW9CFMxA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-chart": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.11.4.tgz",
+      "integrity": "sha512-oBTjx6ytp+/s6zswCuOUQotiISePQKuDUdOsjnbINBPSNvJuE2W9GXHD+B7ibDkCh4ZWXm8obHz7mnrRGbCGFQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^35.11.4",
+        "victory-core": "^35.11.4",
+        "victory-polar-axis": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      }
+    },
+    "victory-core": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.11.4.tgz",
+      "integrity": "sha512-PuqrOIn/a6GQgsp/DKvACiJBAJo71P77jltn56mlDZjAAzz+58BL4E0hx7x908GdodLXo2n9gEeuDdjOAlOt0Q==",
+      "requires": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
+    "victory-create-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.11.4.tgz",
+      "integrity": "sha512-baDLO4GSk/7eTVEYkhikwgwV5BtrSMuNPjKZBjZrIA3Ka9Fn5shklRG9PWg+26JIBFxqZdM6zOvpF7xhjxi37Q==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^35.11.4",
+        "victory-core": "^35.11.4",
+        "victory-cursor-container": "^35.11.4",
+        "victory-selection-container": "^35.11.4",
+        "victory-voronoi-container": "^35.11.4",
+        "victory-zoom-container": "^35.11.4"
+      }
+    },
+    "victory-cursor-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.11.4.tgz",
+      "integrity": "sha512-gs6bwRd/qbGTN78w2QgshIFxlyOsss5qWOMdCcY9i0Oi99l9OJ6UFQDBzSgKsgD53KGs7JxiKevmUqc3qSZZBg==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-group": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.11.4.tgz",
+      "integrity": "sha512-ceFBll9h1sPpdMjNcvdgEhnYELVHfx9ymmk8iMEjOKpxa4fVvapMhegPmL0/zTemJ/NCu71W2xIr0VqyqK0DaA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      }
+    },
+    "victory-legend": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.11.4.tgz",
+      "integrity": "sha512-JZzQARjxYorWlNf9RmZRPAzlgPjukiUV1aTBaeC8YA2S4PhP4PWhNwO/Pb3aCdkifpumpgsm3JULpJiCGOPdBQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-line": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.11.4.tgz",
+      "integrity": "sha512-uKX6/1b1OmlqJZOsVDCCDlyc9QItgb39vRssTwP4CJX1NLU4Sfgq2i4VVUbHXCo/I2sMEczjf3cdnxdZtC6IFA==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-pie": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.11.4.tgz",
+      "integrity": "sha512-EruxP3PIkrTPTzsC5YhiRKg2s+0UtaRU1ZHZUWK8qi+zlbMDFKYg2AlHqsEnctu5AOdOWLLiye6qUG3oxjiURg==",
+      "requires": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-polar-axis": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.11.4.tgz",
+      "integrity": "sha512-mnIRpfARn36TG6ZdCgKR+oWY+pIX6wLHYS0un5xM1TTObKk4IyAR3dnQhEp+3KM1SGoLg0mENFR1Ac8xrus6nQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-scatter": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.11.4.tgz",
+      "integrity": "sha512-8n9rmXmVju2SqA6Xd90rRTmboaU7WStOnj1QUg4q96DDiAVf6kGPdolzCwbUBbiECLyluGoFNJ043WLXztGpiA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-selection-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.11.4.tgz",
+      "integrity": "sha512-Olxnjp9tvHUHeFr4zU/K1dzp0zbeqQRMr2Qqpr85Dd4pWV9bIReE/DanxGhjNg9s3KB5Vsn1GC46PXSTMM1XIQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-shared-events": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+      "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-stack": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.11.4.tgz",
+      "integrity": "sha512-fNTY50fN+DCHcK/9AgMUEq0uJ8IXGnMlRtkSCzMB9ZpEzB7Edx3jLM2Gl970zOkwVaDYXTlikPd1dwf+h3m0dA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-shared-events": "^35.11.4"
+      }
+    },
+    "victory-tooltip": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.11.4.tgz",
+      "integrity": "sha512-B+UUqzryurtMghJGiE34tg5eI44vHxyOOcuPIM3IpJLujnNIJXVykBjgQZnFq1CT/63TtDCOlzPkOjSbecPtXQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
+    },
+    "victory-voronoi-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.11.4.tgz",
+      "integrity": "sha512-vmwHBm/+nZ9qdRcaNd7r08AVRkus/ER6UA4KAYWkKUe50ZT9NYjDxy0wW/Y7PHQldfL9q/VxAyIE/M6jSFWkEA==",
+      "requires": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.11.4",
+        "victory-tooltip": "^35.11.4"
+      }
+    },
+    "victory-zoom-container": {
+      "version": "35.11.4",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.11.4.tgz",
+      "integrity": "sha512-8D4hTdvGZqyZdgWjkz/pDRVy/kijWhptFbK0KWl5J1Tt4YuCGiRC9oxQOpEjlqr8TSyeVnpyuF4QuIp9YOIrAw==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.11.4"
+      }
     },
     "void-elements": {
       "version": "3.1.0",
@@ -18981,6 +19961,11 @@
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "dev": true,
       "requires": {}
+    },
+    "xstate": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.27.0.tgz",
+      "integrity": "sha512-ohOwDM9tViC/zSSmY9261CHblDPqiaAk5vyjVbi69uJv9fGWMzlm0VDQwM2OvC61GKfXVBeuWSMkL7LPUsTpfA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,15 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@patternfly/patternfly": "4.164.2",
-    "@patternfly/react-core": "4.157.3",
-    "@patternfly/react-icons": "4.11.17",
-    "@patternfly/react-styles": "4.11.16",
-    "@patternfly/react-table": "4.30.3",
-    "@rhoas/app-services-ui-shared": "^0.15.4",
+    "@patternfly/react-core": "4.181.1",
+    "@patternfly/react-icons": "4.32.1",
+    "@patternfly/react-styles": "4.31.1",
+    "@patternfly/react-table": "4.50.1",
+    "@rhoas/app-services-ui-components": "1.11.8",
+    "@rhoas/app-services-ui-shared": "0.15.4",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-i18next": "^11.14.3",
+    "react-i18next": "11.14.3",
     "react-router-dom": "5.2.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,35 @@
-import React from 'react';
-import '@patternfly/patternfly/patternfly.css';
+import React, { Suspense } from 'react';
 import { BrowserRouter } from 'react-router-dom';
+import '@patternfly/patternfly/patternfly.css';
 import { AppLayout } from '@app/components/AppLayout/AppLayout';
 import OBRoutes from '@app/OBRoutes/OBRoutes';
+import {
+  AppServicesLoading,
+  I18nProvider,
+} from '@rhoas/app-services-ui-components';
 
 const App = () => {
   return (
-    <BrowserRouter>
-      <AppLayout>
-        <OBRoutes />
-      </AppLayout>
-    </BrowserRouter>
+    <I18nProvider
+      lng="en"
+      resources={{
+        en: {
+          common: () =>
+            import('@rhoas/app-services-ui-components/locales/en/common.json'),
+          openbridgeTempDictionary: () =>
+            import('../locales/en/openbridge.json'),
+        },
+      }}
+      debug={true}
+    >
+      <Suspense fallback={<AppServicesLoading />}>
+        <BrowserRouter>
+          <AppLayout>
+            <OBRoutes />
+          </AppLayout>
+        </BrowserRouter>
+      </Suspense>
+    </I18nProvider>
   );
 };
 

--- a/src/AppFederated.tsx
+++ b/src/AppFederated.tsx
@@ -1,10 +1,40 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import OBRoutes from '@app/OBRoutes/OBRoutes';
 import { useBasename } from '@rhoas/app-services-ui-shared';
+import {
+  AppServicesLoading,
+  I18nProvider,
+} from '@rhoas/app-services-ui-components';
 
 const AppFederated = () => {
   const basename = useBasename();
-  return <OBRoutes baseName={basename?.getBasename()} />;
+  /* The i18n provider is necessary to consume the open bridge dictionary
+        during initial local development. When the first OB UI release will be ready, the
+        OB dictionary will be moved to app-services-ui-components, where
+        all dictionaries reside. See https://issues.redhat.com/browse/MGDOBR-408
+        for more details. */
+  return (
+    <>
+      <I18nProvider
+        lng="en"
+        resources={{
+          en: {
+            common: () =>
+              import(
+                '@rhoas/app-services-ui-components/locales/en/common.json'
+              ),
+            openbridgeTempDictionary: () =>
+              import('../locales/en/openbridge.json'),
+          },
+        }}
+        debug={true}
+      >
+        <Suspense fallback={<AppServicesLoading />}>
+          <OBRoutes baseName={basename?.getBasename()} />
+        </Suspense>
+      </I18nProvider>
+    </>
+  );
 };
 
 export default AppFederated;

--- a/src/app/OBInstance/OBInstancesListPage/OBInstancesListPage.tsx
+++ b/src/app/OBInstance/OBInstancesListPage/OBInstancesListPage.tsx
@@ -14,6 +14,7 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 const OBInstancesListPage = () => {
   const columnNames = ['Name', 'ID', 'Creation date', 'Status'];
@@ -91,11 +92,15 @@ const OBInstancesListPage = () => {
       status: 'Ready',
     },
   ];
+  const { t } = useTranslation();
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
         <TextContent>
-          <Text component="h1">Demo Overview</Text>
+          <Text component="h1">
+            {t('openbridgeTempDictionary:demoOverview')}
+          </Text>
         </TextContent>
       </PageSection>
       <PageSection>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -8,6 +8,10 @@ declare module '*.svg' {
   const content: any;
   export default content;
 }
+declare module '*.json' {
+  const value: any;
+  export default value;
+}
 
 declare function __webpack_init_sharing__(s: string): Promise<void>;
 declare const __webpack_share_scopes__: { [key: string]: any };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -98,12 +98,6 @@ module.exports = (env, argv) => {
         systemvars: true,
         silent: true,
       }),
-      // new CopyPlugin({
-      //   patterns: [{ from: './favicon.png', to: 'images' }],
-      // }),
-      // new CopyPlugin({
-      //   patterns: [{ from: './locales', to: 'locales' }],
-      // }),
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash:8].css',
         chunkFilename: '[contenthash:8].css',
@@ -144,8 +138,16 @@ module.exports = (env, argv) => {
             eager: true,
             requiredVersion: dependencies['react-router-dom'],
           },
-          '@rhoas/app-services-ui-shared': {
+          'react-i18next': {
             eager: true,
+            singleton: true,
+            requiredVersion: dependencies['react-i18next'],
+          },
+          '@rhoas/app-services-ui-components': {
+            singleton: true,
+            requiredVersion: dependencies['@rhoas/app-services-ui-components'],
+          },
+          '@rhoas/app-services-ui-shared': {
             singleton: true,
             requiredVersion: dependencies['@rhoas/app-services-ui-shared'],
           },


### PR DESCRIPTION
https://issues.redhat.com/browse/MGDOBR-393

I've added a translation to display the "Demo Overview" title in the main page as a way to test the i18n setup.

You can run the OB application in standalone mode following the instructions in the [README](https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox-ui#readme).

To run the OB federated module while we still don't have proper `app-services-ui` integration, you can follow this steps:
- first run `sandbox-ui` in federated mode using `npm run start:federate`
- clone the `OB-route` branch of [my fork of app-services-ui](https://github.com/kelvah/app-services-ui/tree/OB-route)
- run `npm install` and then `npm start:dev` in the `app-services-ui` app
- open the following url in the browser: https://prod.foo.redhat.com:1337/beta/application-services/openbridge