### PR TITLE
[MGDOBR-432]: Rename codebase references from "open-bridge" to "smart-events"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Sandbox UI
 
-Sandbox UI for the bridge application.
+Sandbox UI for the smartevents application.
 
 ## Prerequisites
 * Node 16
@@ -26,4 +26,4 @@ npm install
 npm run start:federate
 ```
 
-This will run a dev server on http://localhost:9006 that will serve a federated module named `openbridge`.
+This will run a dev server on http://localhost:9006 that will serve a federated module named `smartevents`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openbridge-ui",
+  "name": "smartevents-ui",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "openbridge-ui",
+      "name": "smartevents-ui",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "openbridge-ui",
+  "name": "smartevents-ui",
   "version": "0.0.1",
-  "federatedModuleName": "openbridge",
+  "federatedModuleName": "smartevents",
   "private": true,
   "scripts": {
     "build": "FEDERATE=1 webpack --mode production --config webpack.prod.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import '@patternfly/patternfly/patternfly.css';
 import { BrowserRouter } from 'react-router-dom';
 import { AppLayout } from '@app/components/AppLayout/AppLayout';
-import OBRoutes from '@app/OBRoutes/OBRoutes';
+import Routes from '@app/Routes/Routes';
 
 const App = () => {
   return (
     <BrowserRouter>
       <AppLayout>
-        <OBRoutes />
+        <Routes />
       </AppLayout>
     </BrowserRouter>
   );

--- a/src/AppFederated.tsx
+++ b/src/AppFederated.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import OBRoutes from '@app/OBRoutes/OBRoutes';
+import Routes from '@app/Routes/Routes';
 import { useBasename } from '@rhoas/app-services-ui-shared';
 
 const AppFederated = () => {
   const basename = useBasename();
-  return <OBRoutes baseName={basename?.getBasename()} />;
+  return <Routes baseName={basename?.getBasename()} />;
 };
 
 export default AppFederated;

--- a/src/app/Instance/InstancePage/InstancePage.tsx
+++ b/src/app/Instance/InstancePage/InstancePage.tsx
@@ -6,7 +6,7 @@ import {
   TextContent,
 } from '@patternfly/react-core';
 
-const OBInstancePage = () => {
+const InstancePage = () => {
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -25,4 +25,4 @@ const OBInstancePage = () => {
   );
 };
 
-export default OBInstancePage;
+export default InstancePage;

--- a/src/app/Instance/InstancesListPage/InstancesListPage.tsx
+++ b/src/app/Instance/InstancesListPage/InstancesListPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 
-const OBInstancesListPage = () => {
+const InstancesListPage = () => {
   const columnNames = ['Name', 'ID', 'Creation date', 'Status'];
   const instances = [
     {
@@ -132,4 +132,4 @@ const OBInstancesListPage = () => {
   );
 };
 
-export default OBInstancesListPage;
+export default InstancesListPage;

--- a/src/app/Routes/Routes.tsx
+++ b/src/app/Routes/Routes.tsx
@@ -1,24 +1,24 @@
 import React from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
-import OBInstancePage from '@app/OBInstance/OBInstancePage/OBInstancePage';
-import OBInstancesListPage from '@app/OBInstance/OBInstancesListPage/OBInstancesListPage';
+import InstancePage from '@app/Instance/InstancePage/InstancePage';
+import InstancesListPage from '@app/Instance/InstancesListPage/InstancesListPage';
 
-interface OBRoutesProps {
+interface RoutesProps {
   /** Used as BrowserRouter basename*/
   baseName?: string;
 }
 
-const OBRoutes = (props: OBRoutesProps) => {
+const Routes = (props: RoutesProps) => {
   const { baseName = '' } = props;
 
   return (
     <BrowserRouter basename={baseName}>
       <Switch>
         <Route exact path={'/'}>
-          <OBInstancesListPage />
+          <InstancesListPage />
         </Route>
         <Route path={`/instance/:id`}>
-          <OBInstancePage />
+          <InstancePage />
         </Route>
         <Route path="*">
           <>
@@ -30,4 +30,4 @@ const OBRoutes = (props: OBRoutesProps) => {
   );
 };
 
-export default OBRoutes;
+export default Routes;

--- a/src/app/components/AppLayout/AppLayout.tsx
+++ b/src/app/components/AppLayout/AppLayout.tsx
@@ -55,7 +55,7 @@ export const AppLayout: FunctionComponent<AppLayoutProps> = ({ children }) => {
       <NavList id="nav-list-simple">
         <NavItem id={'connectors'}>
           <NavLink to={'/'} activeClassName="pf-m-current">
-            OpenBridge
+            SmartEvents
           </NavLink>
         </NavItem>
       </NavList>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -125,7 +125,7 @@ module.exports = (env, argv) => {
           isProduction ? '[chunkhash:8]' : ''
         }.js`,
         exposes: {
-          './OpenBridgeOverview': './src/AppFederated',
+          './SmartEventsOverview': './src/AppFederated',
         },
         shared: {
           ...dependencies,


### PR DESCRIPTION
https://issues.redhat.com/browse/MGDOBR-432

![image](https://user-images.githubusercontent.com/22591802/158538857-118659e4-3300-4b82-a242-92339a151742.png)

For running it, you can follow the same instructions of https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox-ui/pull/4 except that (for the federated scenario) you should refer to [my fork of app-services-ui](https://github.com/vpellegrino/app-services-ui/tree/SE-route) and you should open the URL https://prod.foo.redhat.com:1337/beta/application-services/smartevents