### PR TITLE
MGDOBR-600: Fix Prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,13 +1,5 @@
 {
   "trailingComma": "es5",
   "singleQuote": false,
-  "semi": true,
-  "importOrder": [
-    "^@?xstate/?(.*)$",
-    "^@patternfly/(.*)$",
-    "^@bf2/(.*)$",
-    "^@rhoas/(.*)$",
-    "^[./]"
-  ],
-  "importOrderSeparation": true
+  "semi": true
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/MGDOBR-600

I'm removing two invalid properties from `.prettierrc`. They are causing dozens of warnings while running `npm run format:check`, something like: 

```
[warn] Ignored unknown option { importOrder: ["^@?xstate/?(.*)$", "^@patternfly/(.*)$", "^@bf2/(.*)$", "^@rhoas/(.*)$", "^[./]"] }.
[warn] Ignored unknown option { importOrderSeparation: true }.
```

