### PR TITLE
MGDOBR-466: Update keycloak configuration to use rh sso

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@patternfly/react-table": "4.50.1",
         "@rhoas/app-services-ui-components": "1.11.8",
         "@rhoas/app-services-ui-shared": "0.15.4",
-        "keycloak-js": "15.0.1",
+        "keycloak-js": "9.0.0",
         "monaco-editor": "0.21.3",
         "monaco-editor-webpack-plugin": "2.1.0",
         "react": "17.0.2",
@@ -10506,9 +10506,9 @@
       }
     },
     "node_modules/keycloak-js": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-15.0.1.tgz",
-      "integrity": "sha512-5WBbdZhP39E9nsDJ44P8h1lvQTQawVcydew93fBBoKdSOUmhFPxmcKGS7WwxXqhbVEBe3burdZTFSPzTXfY0ZQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-9.0.0.tgz",
+      "integrity": "sha512-YvxPWKScIrSWCdxfuibTN0HauscsnKJBFhjXk7WAHmcxuEMyR1wRmSjwfxErWlHknJPLNDON5yrK/FDv0CiXlw==",
       "dependencies": {
         "base64-js": "1.3.1",
         "js-sha256": "0.9.0"
@@ -23983,9 +23983,9 @@
       }
     },
     "keycloak-js": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-15.0.1.tgz",
-      "integrity": "sha512-5WBbdZhP39E9nsDJ44P8h1lvQTQawVcydew93fBBoKdSOUmhFPxmcKGS7WwxXqhbVEBe3burdZTFSPzTXfY0ZQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-9.0.0.tgz",
+      "integrity": "sha512-YvxPWKScIrSWCdxfuibTN0HauscsnKJBFhjXk7WAHmcxuEMyR1wRmSjwfxErWlHknJPLNDON5yrK/FDv0CiXlw==",
       "requires": {
         "base64-js": "1.3.1",
         "js-sha256": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@patternfly/react-table": "4.50.1",
     "@rhoas/app-services-ui-components": "1.11.8",
     "@rhoas/app-services-ui-shared": "0.15.4",
-    "keycloak-js": "15.0.1",
+    "keycloak-js": "9.0.0",
     "monaco-editor": "0.21.3",
     "monaco-editor-webpack-plugin": "2.1.0",
     "react": "17.0.2",

--- a/src/Keycloak.tsx
+++ b/src/Keycloak.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/await-thenable */
 import Keycloak from "keycloak-js";
 import React from "react";
 
@@ -21,7 +22,6 @@ const TOKEN_MIN_VALIDITY_SECONDS = 50;
 export const setKeycloakInstance = async (): Promise<void> => {
   if (!keycloak) await init();
 };
-
 /**
  * Initiate keycloak instance.
  *
@@ -36,13 +36,14 @@ export const init = async (): Promise<void> => {
      * See https://issues.redhat.com/browse/MGDOBR-466
      */
     keycloak = Keycloak({
-      realm: "event-bridge-fm",
-      url: "https://keycloak-event-bridge-prod.apps.openbridge-dev.fdvn.p1.openshiftapps.com/auth/",
-      clientId: "event-bridge",
+      realm: "redhat-external",
+      url: "https://sso.redhat.com/auth/",
+      clientId: "cloud-services",
     });
     if (keycloak) {
       await keycloak.init({
         onLoad: "login-required",
+        promiseType: "native",
       });
     }
   } catch (e) {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGDOBR-466

The [integration with rh sso](https://issues.redhat.com/browse/MGDOBR-422) is completed. Updating keycloak config accordingly.

Steps to test it:
- `npm run start`
- rh login screen appears instead of our keycloak one