### PR TITLE
[No Jira] Check the UI SDK is up to date with sandbox/openapi/openapi.yaml

### DIFF
--- a/.github/workflows/openapi-sdk-compatibility-check.yml
+++ b/.github/workflows/openapi-sdk-compatibility-check.yml
@@ -1,0 +1,18 @@
+name: "Smart Events UI :: SDK <-> Openapi compatibility check"
+on: [pull_request, push]
+jobs:
+  run-all-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Fetch latest sandbox/openapi/openapi.yaml"
+        run: |
+          scripts/fetch_openapi.sh
+      - name: "Check 'git diff' result is 0"
+        run: |
+          if ! git diff --exit-code; then
+            echo "Run scripts/fetch_openapi.sh and scripts/generate_openapi_client.sh locally. Open PR afterwards."
+            exit 1
+          else
+            echo "SDK and Openapi are synced."
+          fi


### PR DESCRIPTION
The created code should alert all engineers with new changes in sandbox/openapi/openapi.yaml, that were not downloaded/committed into sandbox-ui repository.