### PR TITLE
MGDOBR-730: [UI] Processors creation issues within mocked APIs

### DIFF
--- a/mocked-api/handlers.ts
+++ b/mocked-api/handlers.ts
@@ -401,6 +401,7 @@ export const handlers = [
     const processor = {
       kind: "Processor",
       id,
+      type: action ? "sink" : "source",
       name,
       href: `/api/v1/bridges/${bridge?.id ?? ""}/processors/${id}`,
       submitted_at: new Date().toISOString(),
@@ -424,7 +425,15 @@ export const handlers = [
       name.includes("fail-create")
     );
 
-    return res(ctx.status(200), ctx.delay(apiDelay), ctx.json(newProcessor));
+    return res(
+      ctx.status(200),
+      ctx.delay(apiDelay),
+      ctx.json(
+        cleanupProcessor(
+          newProcessor as unknown as Record<string | number | symbol, unknown>
+        )
+      )
+    );
   }),
   // delete a processor
   rest.delete(


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-730

Steps to test:
1. `npm run start:mocked`
2. when the application loads, open the browser developer tools
3. create a processor using the UI
4. go to the network panel of the browser developer tools and inspect the response of the creation request (POST /bridges/{bridgeId}/processors)
5. run the following fetch request from the browser developer tools console (replace `{bridgeId}` with the bridge used to create the processor) to get the list of processors including the one created at step 3:
```
fetch("https://event-bridge-event-bridge-prod.apps.openbridge-dev.fdvn.p1.openshiftapps.com/api/v1/bridges/{bridgeId/processors?page=0&size=10", {
  "method": "GET"
});
```