### PR TITLE
MGDOBR-752: Provide links to the SE Instance detail page only when the Instance is "ready"

### DIFF
--- a/src/app/Instance/InstancesListPage/InstancesListPage.tsx
+++ b/src/app/Instance/InstancesListPage/InstancesListPage.tsx
@@ -31,7 +31,7 @@ import { TableWithPaginationSkeleton } from "@app/components/TableWithPagination
 import { useCreateBridgeApi } from "../../../hooks/useBridgesApi/useCreateBridgeApi";
 import axios from "axios";
 import { ResponseError } from "../../../types/Error";
-import { BridgeResponse } from "@openapi/generated";
+import { BridgeResponse, ManagedResourceStatus } from "@openapi/generated";
 
 const InstancesListPage = (): JSX.Element => {
   const { t } = useTranslation(["openbridgeTempDictionary"]);
@@ -49,13 +49,17 @@ const InstancesListPage = (): JSX.Element => {
       label: t("common.name"),
       formatter: (value: IRowData, row?: IRow): JSX.Element => {
         const bridgeId = (row as BridgeResponse)?.id ?? "";
-        return (
+        const status = (row as BridgeResponse)?.status;
+
+        return status === ManagedResourceStatus.Ready ? (
           <Link
             data-testid="tableInstances-linkInstance"
             to={`/instance/${bridgeId}`}
           >
             {value}
           </Link>
+        ) : (
+          <>{value}</>
         );
       },
     },


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-752

Steps to test it:
- create a new SE instance
- wait for it to appear in the list
- there should be no link on its name until it reaches the `ready` status