### PR TITLE
NO-JIRA: Wait instances are loaded before collapsing panel

### DIFF
--- a/cypress/integration/smoke/BasicTest.ts
+++ b/cypress/integration/smoke/BasicTest.ts
@@ -16,13 +16,33 @@ describe("Basic Elements", () => {
     cy.ouiaId("smart-events", "PF4/NavItem").then(($item) => {
       //toggle menu side bar - both directions
       if ($item.is(":visible")) {
+        // wait until data are loaded
+        cy.ouiaType("PF4/TableRow")
+          .should("have.length", 11)
+          .should(($rows) => {
+            expect($rows.eq(1)).contain.text("Instance one");
+          });
+
+        // collapse panel
         cy.get("button#nav-toggle").click();
         cy.ouiaId("smart-events", "PF4/NavItem").should("not.be.visible");
+
+        // expand panel
         cy.get("button#nav-toggle").click();
         cy.ouiaId("smart-events", "PF4/NavItem").should("be.visible");
       } else {
+        // expand panel
         cy.get("button#nav-toggle").click();
         cy.ouiaId("smart-events", "PF4/NavItem").should("be.visible");
+
+        // wait until data are loaded
+        cy.ouiaType("PF4/TableRow")
+          .should("have.length", 11)
+          .should(($rows) => {
+            expect($rows.eq(1)).contain.text("Instance one");
+          });
+
+        // collapse panel
         cy.get("button#nav-toggle").click();
         cy.ouiaId("smart-events", "PF4/NavItem").should("not.be.visible");
       }


### PR DESCRIPTION
Click on panel toggle before data are loaded causing panel is not collapsed

On main the fail looks like:
![Screenshot from 2022-05-27 08-21-56](https://user-images.githubusercontent.com/8044780/170642702-d4367b5a-442e-45f1-bc5a-1cbfcf94651e.png)

It can be spotted aslo on PRs:
- #61 https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox-ui/runs/6613185257?check_suite_focus=true
