### PR TITLE
MGDOBR-782: Remove config, auth and basename contexts/hooks

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -20,7 +20,7 @@ export default {
     "^@apis/(.*)$": "<rootDir>/src/apis/$1",
     "^@constants/(.*)$": "<rootDir>/src/constants/$1",
     "^@utils/(.*)$": "<rootDir>/src/utils/$1",
-    "^@context/(.*)$": "<rootDir>/src/context/$1",
+    "^@contexts/(.*)$": "<rootDir>/src/contexts/$1",
   },
   reporters: ["default"],
   testEnvironment: "jest-environment-jsdom",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,8 @@ import {
   AppServicesLoading,
   I18nProvider,
 } from "@rhoas/app-services-ui-components";
-import { KeycloakAuthProvider, setKeycloakInstance } from "./Keycloak";
-import { Config, ConfigContext } from "@rhoas/app-services-ui-shared";
+import { getKeyCloakToken, getUsername, setKeycloakInstance } from "./Keycloak";
+import { SmartEventsContextProvider } from "@contexts/SmartEventsContext";
 
 const App = (): JSX.Element => {
   const [initialized, setInitialized] = useState(false);
@@ -25,41 +25,37 @@ const App = (): JSX.Element => {
     void init();
   }, []);
 
-  const config = {
-    smart_events: {
-      apiBasePath: process.env.BASE_URL as string,
-    },
-  } as Config;
+  const apiBaseUrl = process.env.BASE_URL as string;
 
   return (
-    <KeycloakAuthProvider>
-      <ConfigContext.Provider value={config}>
-        <I18nProvider
-          lng="en"
-          resources={{
-            en: {
-              common: () =>
-                import(
-                  "@rhoas/app-services-ui-components/locales/en/common.json"
-                ),
-              openbridgeTempDictionary: () =>
-                import("../locales/en/openbridge.json"),
-            },
-          }}
-          debug={true}
-        >
-          <Suspense fallback={<AppServicesLoading />}>
-            <BrowserRouter basename={"/"}>
-              {initialized && (
-                <AppLayout>
-                  <Routes />
-                </AppLayout>
-              )}
-            </BrowserRouter>
-          </Suspense>
-        </I18nProvider>
-      </ConfigContext.Provider>
-    </KeycloakAuthProvider>
+    <I18nProvider
+      lng="en"
+      resources={{
+        en: {
+          common: () =>
+            import("@rhoas/app-services-ui-components/locales/en/common.json"),
+          openbridgeTempDictionary: () =>
+            import("../locales/en/openbridge.json"),
+        },
+      }}
+      debug={true}
+    >
+      <Suspense fallback={<AppServicesLoading />}>
+        <BrowserRouter basename={"/"}>
+          {initialized && (
+            <SmartEventsContextProvider
+              apiBaseUrl={apiBaseUrl}
+              getToken={getKeyCloakToken}
+              getUsername={getUsername}
+            >
+              <AppLayout>
+                <Routes />
+              </AppLayout>
+            </SmartEventsContextProvider>
+          )}
+        </BrowserRouter>
+      </Suspense>
+    </I18nProvider>
   );
 };
 

--- a/src/AppFederated.tsx
+++ b/src/AppFederated.tsx
@@ -1,14 +1,22 @@
 import React, { Suspense } from "react";
-import { useBasename } from "@rhoas/app-services-ui-shared";
 import {
   AppServicesLoading,
   I18nProvider,
 } from "@rhoas/app-services-ui-components";
 import { BrowserRouter } from "react-router-dom";
 import Routes from "@app/Routes/Routes";
+import { SmartEventsContextProvider } from "@contexts/SmartEventsContext";
 
-const AppFederated = (): JSX.Element => {
-  const basename = useBasename();
+export interface AppFederatedProps {
+  apiBaseUrl: string;
+  basename: string;
+  getUsername: () => Promise<string> | undefined;
+  getToken: () => Promise<string> | undefined;
+}
+
+const AppFederated = (props: AppFederatedProps): JSX.Element => {
+  const { basename, getUsername, getToken, apiBaseUrl } = props;
+
   /* The i18n provider is necessary to consume the open bridge dictionary
         during initial local development. When the first OB UI release will be ready, the
         OB dictionary will be moved to app-services-ui-components, where
@@ -31,9 +39,17 @@ const AppFederated = (): JSX.Element => {
         debug={true}
       >
         <Suspense fallback={<AppServicesLoading />}>
-          <BrowserRouter basename={basename?.getBasename()}>
-            <Routes />
-          </BrowserRouter>
+          <SmartEventsContextProvider
+            apiBaseUrl={apiBaseUrl}
+            getToken={async (): Promise<string> => (await getToken()) || ""}
+            getUsername={async (): Promise<string> =>
+              (await getUsername()) || ""
+            }
+          >
+            <BrowserRouter basename={basename}>
+              <Routes />
+            </BrowserRouter>
+          </SmartEventsContextProvider>
         </Suspense>
       </I18nProvider>
     </>

--- a/src/AppMocked.tsx
+++ b/src/AppMocked.tsx
@@ -11,13 +11,7 @@ import {
   AppServicesLoading,
   I18nProvider,
 } from "@rhoas/app-services-ui-components";
-import {
-  Auth,
-  AuthContext,
-  Config,
-  ConfigContext,
-} from "@rhoas/app-services-ui-shared";
-
+import { SmartEventsContextProvider } from "@contexts/SmartEventsContext";
 import { SetupWorkerApi } from "msw/lib/types/setupWorker/glossary";
 
 // App using mocked apis trough msw
@@ -30,47 +24,40 @@ const AppMocked = (): JSX.Element => {
   };
   void worker.start();
 
-  // setting up dummy auth context
-  const authTokenContext = {
-    smart_events: {
-      getToken: () => Promise.resolve("dummy"),
-    },
-    getUsername: () => Promise.resolve("username"),
-  } as Auth;
-
-  const config = {
-    smart_events: {
-      apiBasePath: process.env.BASE_URL as string,
-    },
-  } as Config;
+  const apiBaseUrl = process.env.BASE_URL as string;
+  // setting up dummy auth functions
+  const getToken = (): Promise<string> => Promise.resolve("dummy");
+  const getUsername = (): Promise<string> => Promise.resolve("username");
 
   return (
-    <AuthContext.Provider value={authTokenContext}>
-      <ConfigContext.Provider value={config}>
-        <I18nProvider
-          lng="en"
-          resources={{
-            en: {
-              common: () =>
-                import(
-                  "@rhoas/app-services-ui-components/locales/en/common.json"
-                ),
-              openbridgeTempDictionary: () =>
-                import("../locales/en/openbridge.json"),
-            },
-          }}
-          debug={true}
-        >
-          <Suspense fallback={<AppServicesLoading />}>
-            <BrowserRouter basename={"/"}>
-              <AppLayout>
-                <Routes />
-              </AppLayout>
-            </BrowserRouter>
-          </Suspense>
-        </I18nProvider>
-      </ConfigContext.Provider>
-    </AuthContext.Provider>
+    <SmartEventsContextProvider
+      getToken={getToken}
+      getUsername={getUsername}
+      apiBaseUrl={apiBaseUrl}
+    >
+      <I18nProvider
+        lng="en"
+        resources={{
+          en: {
+            common: () =>
+              import(
+                "@rhoas/app-services-ui-components/locales/en/common.json"
+              ),
+            openbridgeTempDictionary: () =>
+              import("../locales/en/openbridge.json"),
+          },
+        }}
+        debug={true}
+      >
+        <Suspense fallback={<AppServicesLoading />}>
+          <BrowserRouter basename={"/"}>
+            <AppLayout>
+              <Routes />
+            </AppLayout>
+          </BrowserRouter>
+        </Suspense>
+      </I18nProvider>
+    </SmartEventsContextProvider>
   );
 };
 

--- a/src/Keycloak.tsx
+++ b/src/Keycloak.tsx
@@ -1,8 +1,5 @@
 /* eslint-disable @typescript-eslint/await-thenable */
 import Keycloak from "keycloak-js";
-import React from "react";
-
-import { Auth, AuthContext } from "@rhoas/app-services-ui-shared";
 
 export let keycloak: Keycloak.KeycloakInstance | undefined;
 
@@ -31,10 +28,6 @@ export const setKeycloakInstance = async (): Promise<void> => {
  */
 export const init = async (): Promise<void> => {
   try {
-    /* Keycloak configuration using OB authentication.
-     * These params will change after sso is implemented.
-     * See https://issues.redhat.com/browse/MGDOBR-466
-     */
     keycloak = Keycloak({
       realm: "redhat-external",
       url: "https://sso.redhat.com/auth/",
@@ -86,6 +79,17 @@ export const getParsedKeyCloakToken =
     return {} as Keycloak.KeycloakTokenParsed;
   };
 
+export const getUsername = (): Promise<string> => {
+  return getParsedKeyCloakToken().then(
+    (token: unknown) =>
+      (
+        token as {
+          [index: string]: string;
+        }
+      )["username"] ?? ""
+  );
+};
+
 /**
  * logout of keycloak, clear cache and offline store then redirect to
  * keycloak login page
@@ -94,29 +98,4 @@ export const logout = async (): Promise<void> => {
   if (keycloak) {
     await keycloak.logout();
   }
-};
-
-export const KeycloakAuthProvider: React.FunctionComponent = (props) => {
-  const getUsername = (): Promise<string> => {
-    return getParsedKeyCloakToken().then(
-      (token: unknown) =>
-        (
-          token as {
-            [index: string]: string;
-          }
-        )["username"] ?? ""
-    );
-  };
-
-  const authTokenContext = {
-    smart_events: {
-      getToken: getKeyCloakToken,
-    },
-    getUsername: getUsername,
-  } as Auth;
-  return (
-    <AuthContext.Provider value={authTokenContext}>
-      {props.children}
-    </AuthContext.Provider>
-  );
 };

--- a/src/contexts/SmartEventsContext.tsx
+++ b/src/contexts/SmartEventsContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext } from "react";
+
+type AppContextType = {
+  getToken: () => Promise<string>;
+  getUsername: () => Promise<string>;
+  apiBaseUrl: string;
+};
+
+type AppContextProviderProps = AppContextType & {
+  children: React.ReactNode;
+};
+
+const SmartEventsContext = createContext<AppContextType | null>(null);
+
+export const SmartEventsContextProvider = ({
+  getToken,
+  getUsername,
+  apiBaseUrl,
+  children,
+}: AppContextProviderProps): JSX.Element => (
+  <SmartEventsContext.Provider
+    value={{
+      getToken,
+      getUsername,
+      apiBaseUrl,
+    }}
+  >
+    {children}
+  </SmartEventsContext.Provider>
+);
+
+export const useSmartEvents = (): AppContextType => {
+  const context = useContext(SmartEventsContext);
+  if (!context)
+    throw new Error(
+      "useSmartEvents must be used inside an SmartEventsContextProvider"
+    );
+
+  return {
+    ...context,
+  };
+};

--- a/src/hooks/useBridgesApi/useCreateBridgeApi.ts
+++ b/src/hooks/useBridgesApi/useCreateBridgeApi.ts
@@ -4,8 +4,8 @@ import {
   Configuration,
   BridgeResponse,
 } from "@openapi/generated";
-import { useCallback, useState } from "react";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
+import { useState } from "react";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useCreateBridgeApi(): {
   createBridge: (bridgeRequest: BridgeRequest) => void;
@@ -16,12 +16,7 @@ export function useCreateBridgeApi(): {
   const [bridge, setBridge] = useState<BridgeResponse>();
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(false);
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const createBridge = (bridgeRequest: BridgeRequest): void => {
     setIsLoading(true);
@@ -30,7 +25,7 @@ export function useCreateBridgeApi(): {
     const bridgeApi = new BridgesApi(
       new Configuration({
         accessToken: getToken,
-        basePath: config.smart_events.apiBasePath,
+        basePath: apiBaseUrl,
       })
     );
     bridgeApi

--- a/src/hooks/useBridgesApi/useDeleteBridgeApi.ts
+++ b/src/hooks/useBridgesApi/useDeleteBridgeApi.ts
@@ -1,6 +1,6 @@
 import { BridgesApi, Configuration } from "@openapi/generated";
-import { useCallback, useState } from "react";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
+import { useState } from "react";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useDeleteBridgeApi(): {
   deleteBridge: (bridgeId: string) => void;
@@ -11,12 +11,7 @@ export function useDeleteBridgeApi(): {
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(false);
   const [success, setSuccess] = useState<boolean | undefined>();
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const deleteBridge = (bridgeId: string): void => {
     setSuccess(undefined);
@@ -26,7 +21,7 @@ export function useDeleteBridgeApi(): {
     const bridgeApi = new BridgesApi(
       new Configuration({
         accessToken: getToken,
-        basePath: config.smart_events.apiBasePath,
+        basePath: apiBaseUrl,
       })
     );
     bridgeApi

--- a/src/hooks/useBridgesApi/useGetBridgeApi.ts
+++ b/src/hooks/useBridgesApi/useGetBridgeApi.ts
@@ -1,6 +1,6 @@
 import { BridgesApi, Configuration, BridgeResponse } from "@openapi/generated";
 import { useCallback, useState } from "react";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useGetBridgeApi(): {
   getBridge: (bridgeId: string) => void;
@@ -11,19 +11,14 @@ export function useGetBridgeApi(): {
   const [bridge, setBridge] = useState<BridgeResponse>();
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(true);
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const getBridge = useCallback(
     (bridgeId: string): void => {
       const bridgeApi = new BridgesApi(
         new Configuration({
           accessToken: getToken,
-          basePath: config.smart_events.apiBasePath,
+          basePath: apiBaseUrl,
         })
       );
       bridgeApi
@@ -32,7 +27,7 @@ export function useGetBridgeApi(): {
         .catch((err) => setError(err))
         .finally(() => setIsLoading(false));
     },
-    [getToken, config]
+    [getToken, apiBaseUrl]
   );
 
   return { getBridge, isLoading, bridge, error };

--- a/src/hooks/useBridgesApi/useGetBridgesApi.ts
+++ b/src/hooks/useBridgesApi/useGetBridgesApi.ts
@@ -4,8 +4,8 @@ import {
   Configuration,
 } from "@openapi/generated";
 import { useCallback, useRef, useState } from "react";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
 import axios, { CancelTokenSource } from "axios";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useGetBridgesApi(): {
   getBridges: (pageReq?: number, sizeReq?: number, isPolling?: boolean) => void;
@@ -18,12 +18,7 @@ export function useGetBridgesApi(): {
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(true);
   const prevCallTokenSource = useRef<CancelTokenSource>();
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const getBridges = useCallback(
     (pageReq?: number, sizeReq?: number, isPolling = false): void => {
@@ -37,7 +32,7 @@ export function useGetBridgesApi(): {
       const bridgeApi = new BridgesApi(
         new Configuration({
           accessToken: getToken,
-          basePath: config.smart_events.apiBasePath,
+          basePath: apiBaseUrl,
         })
       );
       bridgeApi
@@ -55,7 +50,7 @@ export function useGetBridgesApi(): {
           }
         });
     },
-    [getToken, config]
+    [getToken, apiBaseUrl]
   );
 
   return { getBridges, isLoading, bridgeListResponse, error };

--- a/src/hooks/useProcessorsApi/useAddProcessorToBridgeApi.ts
+++ b/src/hooks/useProcessorsApi/useAddProcessorToBridgeApi.ts
@@ -4,8 +4,8 @@ import {
   ProcessorRequest,
   ProcessorsApi,
 } from "@openapi/generated";
-import { useCallback, useState } from "react";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
+import { useState } from "react";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useAddProcessorToBridgeApi(): {
   addProcessorToBridge: (
@@ -19,12 +19,7 @@ export function useAddProcessorToBridgeApi(): {
   const [processor, setProcessor] = useState<ProcessorResponse>();
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(false);
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const addProcessorToBridge = (
     bridgeId: string,
@@ -36,7 +31,7 @@ export function useAddProcessorToBridgeApi(): {
     const processorsApi = new ProcessorsApi(
       new Configuration({
         accessToken: getToken,
-        basePath: config.smart_events.apiBasePath,
+        basePath: apiBaseUrl,
       })
     );
     processorsApi

--- a/src/hooks/useProcessorsApi/useDeleteProcessorApi.ts
+++ b/src/hooks/useProcessorsApi/useDeleteProcessorApi.ts
@@ -1,6 +1,6 @@
 import { Configuration, ProcessorsApi } from "@openapi/generated";
-import { useCallback, useState } from "react";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
+import { useState } from "react";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useDeleteProcessorApi(): {
   deleteProcessor: (bridgeId: string, processorId: string) => void;
@@ -11,12 +11,7 @@ export function useDeleteProcessorApi(): {
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(false);
   const [success, setSuccess] = useState<boolean | undefined>();
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const deleteProcessor = (bridgeId: string, processorId: string): void => {
     setSuccess(undefined);
@@ -26,7 +21,7 @@ export function useDeleteProcessorApi(): {
     const processorsApi = new ProcessorsApi(
       new Configuration({
         accessToken: getToken,
-        basePath: config.smart_events.apiBasePath,
+        basePath: apiBaseUrl,
       })
     );
     processorsApi

--- a/src/hooks/useProcessorsApi/useGetProcessorApi.ts
+++ b/src/hooks/useProcessorsApi/useGetProcessorApi.ts
@@ -4,7 +4,7 @@ import {
   ProcessorsApi,
 } from "@openapi/generated";
 import { useCallback, useState } from "react";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useGetProcessorApi(): {
   getProcessor: (bridgeId: string, processorId: string) => void;
@@ -15,19 +15,14 @@ export function useGetProcessorApi(): {
   const [processor, setProcessor] = useState<ProcessorResponse>();
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(true);
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const getProcessor = useCallback(
     (bridgeId: string, processorId: string) => {
       const processorsApi = new ProcessorsApi(
         new Configuration({
           accessToken: getToken,
-          basePath: config.smart_events.apiBasePath,
+          basePath: apiBaseUrl,
         })
       );
       processorsApi
@@ -36,7 +31,7 @@ export function useGetProcessorApi(): {
         .catch((err) => setError(err))
         .finally(() => setIsLoading(false));
     },
-    [getToken, config]
+    [getToken, apiBaseUrl]
   );
 
   return { getProcessor, isLoading, processor, error };

--- a/src/hooks/useProcessorsApi/useGetProcessorsApi.ts
+++ b/src/hooks/useProcessorsApi/useGetProcessorsApi.ts
@@ -5,7 +5,7 @@ import {
 } from "@openapi/generated";
 import { useCallback, useRef, useState } from "react";
 import axios, { CancelTokenSource } from "axios";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useGetProcessorsApi(): {
   getProcessors: (
@@ -23,12 +23,7 @@ export function useGetProcessorsApi(): {
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(true);
   const prevCallTokenSource = useRef<CancelTokenSource>();
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const getProcessors = useCallback(
     (
@@ -47,7 +42,7 @@ export function useGetProcessorsApi(): {
       const processorsApi = new ProcessorsApi(
         new Configuration({
           accessToken: getToken,
-          basePath: config.smart_events.apiBasePath,
+          basePath: apiBaseUrl,
         })
       );
       processorsApi
@@ -65,7 +60,7 @@ export function useGetProcessorsApi(): {
           }
         });
     },
-    [getToken, config]
+    [getToken, apiBaseUrl]
   );
 
   return { getProcessors, isLoading, processorListResponse, error };

--- a/src/hooks/useProcessorsApi/useUpdateProcessorApi.ts
+++ b/src/hooks/useProcessorsApi/useUpdateProcessorApi.ts
@@ -4,8 +4,8 @@ import {
   ProcessorRequest,
   ProcessorsApi,
 } from "@openapi/generated";
-import { useCallback, useState } from "react";
-import { useAuth, useConfig } from "@rhoas/app-services-ui-shared";
+import { useState } from "react";
+import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useUpdateProcessorApi(): {
   updateProcessor: (
@@ -20,12 +20,7 @@ export function useUpdateProcessorApi(): {
   const [processor, setProcessor] = useState<ProcessorResponse>();
   const [error, setError] = useState<unknown>();
   const [isLoading, setIsLoading] = useState(false);
-  const auth = useAuth();
-  const config = useConfig();
-
-  const getToken = useCallback(async (): Promise<string> => {
-    return (await auth.smart_events.getToken()) || "";
-  }, [auth]);
+  const { getToken, apiBaseUrl } = useSmartEvents();
 
   const updateProcessor = (
     bridgeId: string,
@@ -38,7 +33,7 @@ export function useUpdateProcessorApi(): {
     const processorsApi = new ProcessorsApi(
       new Configuration({
         accessToken: getToken,
-        basePath: config.smart_events.apiBasePath,
+        basePath: apiBaseUrl,
       })
     );
     processorsApi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
       "@apis/*": ["src/apis/*"],
       "@constants/*": ["src/constants/*"],
       "@utils/*": ["src/utils/*"],
-      "@context/*": ["src/context/*"],
+      "@contexts/*": ["src/contexts/*"],
       "@openapi/*": ["openapi/*"]
     }
   }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-782

Auth related functions, `apiBaseUrl` and `basename` are now passed as props to our application and shared internally through the new `SmartEventsContext`. 

`useAuth`, `useConfig` and `useBasename` are no longer used.

See jira link for further details.
