### PR TITLE
MGDOBR-732: Remove transformation template section from source processors creation form

### DIFF
--- a/src/app/Processor/ProcessorEdit/ProcessorEdit.test.tsx
+++ b/src/app/Processor/ProcessorEdit/ProcessorEdit.test.tsx
@@ -67,7 +67,7 @@ describe("ProcessorEdit component", () => {
 
     expect(comp.queryByText("Source")).toBeInTheDocument();
     expect(comp.queryByText("Filters")).toBeInTheDocument();
-    expect(comp.queryByText("Transformation")).toBeInTheDocument();
+    expect(comp.queryByText("Transformation")).not.toBeInTheDocument();
     expect(comp.queryByText("Action")).not.toBeInTheDocument();
   });
 

--- a/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
+++ b/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
@@ -29,6 +29,7 @@ import {
   ProcessorRequest,
   ProcessorResponse,
   ProcessorSchemaEntryResponse,
+  ProcessorType,
 } from "@openapi/generated";
 import {
   EventFilter,
@@ -78,7 +79,9 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
     () => processor !== undefined,
     [processor]
   );
-  const [processorType, setProcessorType] = useState(processor?.type ?? "");
+  const [processorType, setProcessorType] = useState<ProcessorType | undefined>(
+    processor?.type
+  );
   const [name, setName] = useState(processor?.name ?? "");
   const [filters, setFilters] = useState<EventFilter[]>(
     (processor?.filters as unknown as EventFilter[]) ?? [
@@ -169,7 +172,7 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
 
   const prepareRequest = (formData: ProcessorFormData): ProcessorRequest => {
     const requestData: ProcessorRequest = { name: formData.name };
-    if (formData.type === "sink") {
+    if (formData.type === ProcessorType.Sink) {
       requestData.action = formData.action;
     } else {
       requestData.source = formData.source;
@@ -291,10 +294,12 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
                                 title={t("processor.sourceProcessor")}
                                 data-ouia-component-id="source"
                                 data-ouia-component-type="Tile"
-                                isSelected={processorType === "source"}
+                                isSelected={
+                                  processorType === ProcessorType.Source
+                                }
                                 style={{ height: "100%" }}
                                 onClick={(): void => {
-                                  setProcessorType("source");
+                                  setProcessorType(ProcessorType.Source);
                                   resetValidation("processorType");
                                 }}
                               >
@@ -307,9 +312,11 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
                                 data-ouia-component-id="sink"
                                 data-ouia-component-type="Tile"
                                 style={{ width: "100%", height: "100%" }}
-                                isSelected={processorType === "sink"}
+                                isSelected={
+                                  processorType === ProcessorType.Sink
+                                }
                                 onClick={(): void => {
-                                  setProcessorType("sink");
+                                  setProcessorType(ProcessorType.Sink);
                                   resetValidation("processorType");
                                 }}
                               >
@@ -348,9 +355,9 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
                         />
                       </FormGroup>
                     </FormSection>
-                    {processorType !== "" && (
+                    {processorType && (
                       <>
-                        {processorType === "source" && (
+                        {processorType === ProcessorType.Source && (
                           <FormSection title={t("processor.source")}>
                             <TextContent>
                               <Text
@@ -383,45 +390,48 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
                             onChange={setFilters}
                           />
                         </FormSection>
-                        <FormSection title={t("processor.transformation")}>
-                          <TextContent>
-                            <Text
-                              component="p"
-                              ouiaId={"transformation-description"}
-                            >
-                              {t("processor.addTransformationDescription")}
-                            </Text>
-                          </TextContent>
-                          <CodeEditor
-                            id={"transformation-template"}
-                            height={"300px"}
-                            isLineNumbersVisible={true}
-                            code={transformation}
-                            onChange={setTransformation}
-                            options={{
-                              scrollbar: { alwaysConsumeMouseWheel: false },
-                            }}
-                          />
-                        </FormSection>
-                        {processorType === "sink" && (
-                          <FormSection title={t("processor.action")}>
-                            <TextContent>
-                              <Text component="p" ouiaId="action-description">
-                                {t("processor.selectActionDescription")}
-                              </Text>
-                            </TextContent>
-                            <ConfigurationEdit
-                              configType={ProcessorSchemaType.ACTION}
-                              action={action}
-                              registerValidation={registerValidateConfig}
-                              onChange={setAction}
-                              readOnly={isExistingProcessor}
-                              schemaCatalog={schemaCatalog}
-                              getSchema={getSchema}
-                            />
-                          </FormSection>
+
+                        {processorType === ProcessorType.Sink && (
+                          <>
+                            <FormSection title={t("processor.transformation")}>
+                              <TextContent>
+                                <Text
+                                  component="p"
+                                  ouiaId={"transformation-description"}
+                                >
+                                  {t("processor.addTransformationDescription")}
+                                </Text>
+                              </TextContent>
+                              <CodeEditor
+                                id={"transformation-template"}
+                                height={"300px"}
+                                isLineNumbersVisible={true}
+                                code={transformation}
+                                onChange={setTransformation}
+                                options={{
+                                  scrollbar: { alwaysConsumeMouseWheel: false },
+                                }}
+                              />
+                            </FormSection>
+                            <FormSection title={t("processor.action")}>
+                              <TextContent>
+                                <Text component="p" ouiaId="action-description">
+                                  {t("processor.selectActionDescription")}
+                                </Text>
+                              </TextContent>
+                              <ConfigurationEdit
+                                configType={ProcessorSchemaType.ACTION}
+                                action={action}
+                                registerValidation={registerValidateConfig}
+                                onChange={setAction}
+                                readOnly={isExistingProcessor}
+                                schemaCatalog={schemaCatalog}
+                                getSchema={getSchema}
+                              />
+                            </FormSection>
+                          </>
                         )}
-                        {processorType !== "" && (
+                        {processorType && (
                           <AlertGroup
                             className={"processor-edit__form__notice"}
                           >

--- a/src/app/Processor/ProcessorEdit/useValidateProcessor.ts
+++ b/src/app/Processor/ProcessorEdit/useValidateProcessor.ts
@@ -64,7 +64,7 @@ export function useValidateProcessor(
   }, [name, resetValidation, existingProcessorName, t]);
 
   const validateProcessorType = useCallback((): boolean => {
-    if (isEmpty(type)) {
+    if (!type) {
       setValidation((prevState) => ({
         ...prevState,
         errors: {

--- a/src/types/Processor.ts
+++ b/src/types/Processor.ts
@@ -1,4 +1,4 @@
-import { Action, Source } from "@openapi/generated";
+import { Action, ProcessorType, Source } from "@openapi/generated";
 
 export type Processor = SinkProcessor | SourceProcessor;
 
@@ -28,7 +28,7 @@ export interface EventFilter {
 
 export interface ProcessorFormData {
   name: string;
-  type: string;
+  type?: ProcessorType;
   action?: Action;
   transformationTemplate?: string;
   filters?: EventFilter[];


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-732

Removing the ability to add a transformation template to source processors. It's not supported by APIs and it won't be for the foreseeable future.

To test it:
- Create a processor
- Select "source" type
- Transformation template field is not there anymore
- :champagne: 