### PR TITLE
MGDOBR-904: Default values handling within action/source configuration form of a processor

### DIFF
--- a/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
+++ b/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
@@ -112,8 +112,10 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
       field.type === "string" &&
       typeof enumValues !== "undefined"
     ) {
-      if (enumValues[0] !== "") {
+      if (field.default === undefined && enumValues[0] !== "") {
         newEnumValues = ["", ...enumValues];
+      } else {
+        newEnumValues = enumValues;
       }
     }
     // Due to:

--- a/src/app/Processor/ProcessorEdit/ConfigurationForm/validator.ts
+++ b/src/app/Processor/ProcessorEdit/ConfigurationForm/validator.ts
@@ -5,7 +5,7 @@ import ajv from "ajv-errors";
 
 const ajvInstance = new Ajv2019({
   allErrors: true,
-  useDefaults: false,
+  useDefaults: true,
   strict: "log",
   strictSchema: false,
 });


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-904

Long story short: default values of optional fields inside action/source configuration forms were not included in the processor creation request. See jira link for more details.

Steps to test it:

- Create a new source processor
- Enter a processor name
- Select a source with fields that have default values (like `AWS S3 source`)
- Fill in required fields without touching optional fields with default values
- Submit the form
- Open the processor you just created
- Default values are there
- :champagne: 