### PR TITLE
MGDOBR-898: Public API returns ErrorsResponse

### DIFF
--- a/mocked-api/handlers.ts
+++ b/mocked-api/handlers.ts
@@ -118,10 +118,15 @@ export const handlers = [
       ctx.status(404),
       ctx.delay(apiDelay),
       ctx.json({
-        ...error_not_found,
-        reason: `Bridge with id '${
-          bridgeId as string
-        }' for customer 'XXXXXXXX' does not exist`,
+        kind: "ErrorList",
+        items: [
+          {
+            ...error_not_found,
+            reason: `Bridge with id '${
+              bridgeId as string
+            }' for customer 'XXXXXXXX' does not exist`,
+          },
+        ],
       })
     );
   }),
@@ -141,8 +146,13 @@ export const handlers = [
       return res(
         ctx.status(400),
         ctx.json({
-          ...error_duplicated_resource,
-          reason: `Bridge with name '${name}' already exists for customer with id 'XXXXXXXX'`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_duplicated_resource,
+              reason: `Bridge with name '${name}' already exists for customer with id 'XXXXXXXX'`,
+            },
+          ],
         })
       );
     }
@@ -151,8 +161,13 @@ export const handlers = [
       return res(
         ctx.status(500),
         ctx.json({
-          ...error_external_component,
-          reason: `Creation was no successful probably due to external component fail'`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_external_component,
+              reason: `Creation was no successful probably due to external component fail'`,
+            },
+          ],
         })
       );
     }
@@ -193,12 +208,17 @@ export const handlers = [
       },
     });
 
-    if (existingBridge!.name == "error-test") {
+    if (existingBridge?.name == "error-test") {
       return res(
         ctx.status(500),
         ctx.json({
-          ...error_external_component,
-          reason: `Deletion was no successful probably due to external component fail'`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_external_component,
+              reason: `Deletion was no successful probably due to external component fail'`,
+            },
+          ],
         })
       );
     }
@@ -208,10 +228,15 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          ...error_not_found,
-          reason: `Bridge with id '${
-            bridgeId as string
-          }' for customer 'XXXXXXXX' does not exist`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_not_found,
+              reason: `Bridge with id '${
+                bridgeId as string
+              }' for customer 'XXXXXXXX' does not exist`,
+            },
+          ],
         })
       );
     }
@@ -230,7 +255,10 @@ export const handlers = [
       return res(
         ctx.status(400),
         ctx.delay(apiDelay),
-        ctx.json(error_bridge_not_deletable)
+        ctx.json({
+          kind: "ErrorList",
+          items: [error_bridge_not_deletable],
+        })
       );
     }
 
@@ -277,10 +305,15 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          ...error_not_found,
-          reason: `Bridge with id '${
-            bridgeId as string
-          }' for customer 'XXXXXXXX' does not exist`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_not_found,
+              reason: `Bridge with id '${
+                bridgeId as string
+              }' for customer 'XXXXXXXX' does not exist`,
+            },
+          ],
         })
       );
     }
@@ -341,10 +374,15 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            ...error_not_found,
-            reason: `Bridge with id '${
-              bridgeId as string
-            }' for customer 'XXXXXXXX' does not exist`,
+            kind: "ErrorList",
+            items: [
+              {
+                ...error_not_found,
+                reason: `Bridge with id '${
+                  bridgeId as string
+                }' for customer 'XXXXXXXX' does not exist`,
+              },
+            ],
           })
         );
       }
@@ -373,10 +411,15 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          ...error_not_found,
-          reason: `Processor with id '${
-            processorId as string
-          }' for customer 'XXXXXXXX' does not exist`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_not_found,
+              reason: `Processor with id '${
+                processorId as string
+              }' for customer 'XXXXXXXX' does not exist`,
+            },
+          ],
         })
       );
     }
@@ -400,10 +443,15 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          ...error_not_found,
-          reason: `Bridge with id '${
-            bridgeId as string
-          }' for customer 'XXXXXXXX' does not exist`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_not_found,
+              reason: `Bridge with id '${
+                bridgeId as string
+              }' for customer 'XXXXXXXX' does not exist`,
+            },
+          ],
         })
       );
     }
@@ -425,10 +473,15 @@ export const handlers = [
       return res(
         ctx.status(400),
         ctx.json({
-          ...error_duplicated_resource,
-          reason: `Processor with name '${name}' already exists for bridge with id ${
-            bridgeId as string
-          } for customer with id 'XXXXXXXXXX'`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_duplicated_resource,
+              reason: `Processor with name '${name}' already exists for bridge with id ${
+                bridgeId as string
+              } for customer with id 'XXXXXXXXXX'`,
+            },
+          ],
         })
       );
     }
@@ -503,10 +556,15 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            ...error_not_found,
-            reason: `Bridge with id '${
-              bridgeId as string
-            }' for customer 'XXXXXXXX' does not exist`,
+            kind: "ErrorList",
+            items: [
+              {
+                ...error_not_found,
+                reason: `Bridge with id '${
+                  bridgeId as string
+                }' for customer 'XXXXXXXX' does not exist`,
+              },
+            ],
           })
         );
       }
@@ -524,10 +582,15 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            ...error_not_found,
-            reason: `Processor with id '${
-              processorId as string
-            }' for customer 'XXXXXXXX' does not exist`,
+            kind: "ErrorList",
+            items: [
+              {
+                ...error_not_found,
+                reason: `Processor with id '${
+                  processorId as string
+                }' for customer 'XXXXXXXX' does not exist`,
+              },
+            ],
           })
         );
       }
@@ -552,10 +615,15 @@ export const handlers = [
         return res(
           ctx.status(400),
           ctx.json({
-            ...error_duplicated_resource,
-            reason: `Processor with name '${name}' already exists for bridge with id ${
-              bridgeId as string
-            } for customer with id 'XXXXXXXXXX'`,
+            kind: "ErrorList",
+            items: [
+              {
+                ...error_duplicated_resource,
+                reason: `Processor with name '${name}' already exists for bridge with id ${
+                  bridgeId as string
+                } for customer with id 'XXXXXXXXXX'`,
+              },
+            ],
           })
         );
       }
@@ -620,10 +688,15 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            ...error_not_found,
-            reason: `Bridge with id '${
-              bridgeId as string
-            }' for customer 'XXXXXXXX' does not exist`,
+            kind: "ErrorList",
+            items: [
+              {
+                ...error_not_found,
+                reason: `Bridge with id '${
+                  bridgeId as string
+                }' for customer 'XXXXXXXX' does not exist`,
+              },
+            ],
           })
         );
       }
@@ -646,10 +719,15 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            ...error_not_found,
-            reason: `Processor with id '${
-              bridgeId as string
-            }' for customer 'XXXXXXXX' does not exist`,
+            kind: "ErrorList",
+            items: [
+              {
+                ...error_not_found,
+                reason: `Processor with id '${
+                  bridgeId as string
+                }' for customer 'XXXXXXXX' does not exist`,
+              },
+            ],
           })
         );
       }
@@ -698,10 +776,15 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          ...error_not_found,
-          reason: `The processor json schema '${
-            schemaId as string
-          }' is not in the catalog.`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_not_found,
+              reason: `The processor json schema '${
+                schemaId as string
+              }' is not in the catalog.`,
+            },
+          ],
         })
       );
     }
@@ -719,10 +802,15 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          ...error_not_found,
-          reason: `The processor json schema '${
-            schemaId as string
-          }' is not in the catalog.`,
+          kind: "ErrorList",
+          items: [
+            {
+              ...error_not_found,
+              reason: `The processor json schema '${
+                schemaId as string
+              }' is not in the catalog.`,
+            },
+          ],
         })
       );
     }

--- a/mocked-api/handlers.ts
+++ b/mocked-api/handlers.ts
@@ -118,7 +118,7 @@ export const handlers = [
       ctx.status(404),
       ctx.delay(apiDelay),
       ctx.json({
-        kind: "ErrorList",
+        kind: "ErrorsResponse",
         items: [
           {
             ...error_not_found,
@@ -146,7 +146,7 @@ export const handlers = [
       return res(
         ctx.status(400),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_duplicated_resource,
@@ -161,7 +161,7 @@ export const handlers = [
       return res(
         ctx.status(500),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_external_component,
@@ -212,7 +212,7 @@ export const handlers = [
       return res(
         ctx.status(500),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_external_component,
@@ -228,7 +228,7 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_not_found,
@@ -256,7 +256,7 @@ export const handlers = [
         ctx.status(400),
         ctx.delay(apiDelay),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [error_bridge_not_deletable],
         })
       );
@@ -305,7 +305,7 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_not_found,
@@ -374,7 +374,7 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            kind: "ErrorList",
+            kind: "ErrorsResponse",
             items: [
               {
                 ...error_not_found,
@@ -411,7 +411,7 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_not_found,
@@ -443,7 +443,7 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_not_found,
@@ -473,7 +473,7 @@ export const handlers = [
       return res(
         ctx.status(400),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_duplicated_resource,
@@ -556,7 +556,7 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            kind: "ErrorList",
+            kind: "ErrorsResponse",
             items: [
               {
                 ...error_not_found,
@@ -582,7 +582,7 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            kind: "ErrorList",
+            kind: "ErrorsResponse",
             items: [
               {
                 ...error_not_found,
@@ -615,7 +615,7 @@ export const handlers = [
         return res(
           ctx.status(400),
           ctx.json({
-            kind: "ErrorList",
+            kind: "ErrorsResponse",
             items: [
               {
                 ...error_duplicated_resource,
@@ -688,7 +688,7 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            kind: "ErrorList",
+            kind: "ErrorsResponse",
             items: [
               {
                 ...error_not_found,
@@ -719,7 +719,7 @@ export const handlers = [
           ctx.status(404),
           ctx.delay(apiDelay),
           ctx.json({
-            kind: "ErrorList",
+            kind: "ErrorsResponse",
             items: [
               {
                 ...error_not_found,
@@ -776,7 +776,7 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_not_found,
@@ -802,7 +802,7 @@ export const handlers = [
         ctx.status(404),
         ctx.delay(apiDelay),
         ctx.json({
-          kind: "ErrorList",
+          kind: "ErrorsResponse",
           items: [
             {
               ...error_not_found,

--- a/openapi/generated/errorHelpers.ts
+++ b/openapi/generated/errorHelpers.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from "axios";
+import { ErrorListResponse } from "@openapi/generated/model";
 
 /**
  * Check if the error code originates from the API
@@ -7,15 +8,17 @@ import { AxiosError } from "axios";
  * @returns true if error originated from the API
  */
 export const isServiceApiError = (error: unknown): error is AxiosError => {
-    return (error as AxiosError).response?.data.code !== undefined;
+    const errorListResponse = (error as AxiosError).response?.data as ErrorListResponse;
+    return errorListResponse?.items !== undefined;
 };
 
 /**
- * Get the error code from the API error
+ * Get the error code related to the first error item returned from the API
  *
  * @param error generic error returned from function
  * @returns error code (one of fields of APIErrorCodes)
  */
 export const getErrorCode = (error: unknown): string | undefined => {
-    return (error as AxiosError).response?.data?.code;
+    const errorListResponse = (error as AxiosError).response?.data as ErrorListResponse;
+    return errorListResponse?.items?.length ? errorListResponse?.items[0].code : undefined;
 };

--- a/openapi/generated/errors.ts
+++ b/openapi/generated/errors.ts
@@ -19,7 +19,7 @@ export const APIErrorCodes = {
   /** You tried a life cycle transition which is not allowed*/
   ERROR_2 : "OPENBRIDGE-2", 
 
-  /** The requested item does not exist in out repository*/
+  /** We were unable to process your request. Please contact Red Hat support if the error persists.*/
   ERROR_3 : "OPENBRIDGE-3", 
 
   /** You tried to create an object which already exist in our repository*/
@@ -46,4 +46,34 @@ export const APIErrorCodes = {
   /** You tried a life cycle transition which is not allowed*/
   ERROR_19 : "OPENBRIDGE-19", 
 
-}
+  /** The Transformation Template for the Processor is invalid*/
+  ERROR_22 : "OPENBRIDGE-22", 
+
+  /** The Processor is missing a Gateway definition.*/
+  ERROR_23 : "OPENBRIDGE-23", 
+
+  /** The Processor Gateway definition is missing parameters.*/
+  ERROR_24 : "OPENBRIDGE-24", 
+
+  /** The Processor Gateway type is not recognised.*/
+  ERROR_25 : "OPENBRIDGE-25", 
+
+  /** One or more of the Processor Gateway parameters are invalid.*/
+  ERROR_26 : "OPENBRIDGE-26", 
+
+  /** One or more of the Processor Gateway parameters are invalid.*/
+  ERROR_27 : "OPENBRIDGE-27", 
+
+  /** A Processor cannot have both a Source and an Action Gateway defined.*/
+  ERROR_28 : "OPENBRIDGE-28", 
+
+  /** Processor Source Gateways do not support Transformation Templates.*/
+  ERROR_29 : "OPENBRIDGE-29", 
+
+  /** The specified ErrorHandler Action is unsupported.*/
+  ERROR_30 : "OPENBRIDGE-30", 
+
+  /** Unable to deserialize Filter definition.*/
+  ERROR_32 : "OPENBRIDGE-32", 
+
+};


### PR DESCRIPTION
**Task**: https://issues.redhat.com/browse/MGDOBR-898
**Description**: Changing the function `getErrorCode` in `errorHelpers` to consider the first error returned by the APIs.
Consider that we could add new functions to the helper when we need to report multiple errors on the page or search for a particular error code among all returned error items.