### PR TITLE
NO-JIRA: Fix mocked processors following updates to schema catalog

### DIFF
--- a/mocked-api/data.ts
+++ b/mocked-api/data.ts
@@ -147,11 +147,6 @@ export const processorData = [
     action: {
       type: "slack_sink_0.1",
       parameters: JSON.stringify({
-        data_shape: {
-          consumes: {
-            format: "application/octet-stream",
-          },
-        },
         slack_channel: "#test",
         slack_webhook_url:
           "https://hooks.slack.com/services/XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXX",
@@ -181,11 +176,6 @@ export const processorData = [
         slack_channel: "test",
         slack_webhook_url:
           "https://hooks.slack.com/services/XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXX",
-        data_shape: {
-          consumes: {
-            format: "application/octet-stream",
-          },
-        },
       }),
     },
   },
@@ -210,11 +200,6 @@ export const processorData = [
       parameters: JSON.stringify({
         slack_channel: "#test",
         slack_token: "***********",
-        data_shape: {
-          consumes: {
-            format: "application/octet-stream",
-          },
-        },
       }),
     },
   },
@@ -233,11 +218,6 @@ export const processorData = [
       parameters: JSON.stringify({
         slack_channel: "#test",
         slack_token: "***********",
-        data_shape: {
-          consumes: {
-            format: "application/octet-stream",
-          },
-        },
       }),
     },
   },


### PR DESCRIPTION
Following PR #94, mocked processors needed a cleanup. 
They still had the data-shape properties that no longer exist in the Slack [action](https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox-ui/blob/391cc7b0f2a4e4adca7691e6c874eeede137b367/mocked-api/schemasData.ts#L183)/[source](https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox-ui/blob/391cc7b0f2a4e4adca7691e6c874eeede137b367/mocked-api/schemasData.ts#L688) schemas.

Thanks @vpellegrino for spotting this.