### PR TITLE
[NO-JIRA]: Retrieving the error cause from the first error item

### DIFF
--- a/openapi/generated/errorHelpers.ts
+++ b/openapi/generated/errorHelpers.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from "axios";
-import { ErrorListResponse } from "@openapi/generated/model";
+import { ErrorListResponse, ErrorResponse } from "@openapi/generated/model";
 
 /**
  * Check if the error code originates from the API
@@ -13,12 +13,32 @@ export const isServiceApiError = (error: unknown): error is AxiosError => {
 };
 
 /**
+ * Get the first error item returned from the API
+ *
+ * @param error generic error returned from function
+ * @returns error item (a single ErrorResponse)
+ */
+export const getFirstError = (error: unknown): ErrorResponse | undefined => {
+    const errorListResponse = (error as AxiosError).response?.data as ErrorListResponse;
+    return errorListResponse?.items?.length ? errorListResponse?.items[0] : undefined;
+};
+
+/**
  * Get the error code related to the first error item returned from the API
  *
  * @param error generic error returned from function
  * @returns error code (one of fields of APIErrorCodes)
  */
 export const getErrorCode = (error: unknown): string | undefined => {
-    const errorListResponse = (error as AxiosError).response?.data as ErrorListResponse;
-    return errorListResponse?.items?.length ? errorListResponse?.items[0].code : undefined;
+    return getFirstError(error)?.code;
+};
+
+/**
+ * Get the error reason related to the first error item returned from the API
+ *
+ * @param error generic error returned from function
+ * @returns error reason
+ */
+export const getErrorReason = (error: unknown): string | undefined => {
+    return getFirstError(error)?.reason;
 };

--- a/src/app/Instance/DeleteInstance/DeleteInstance.tsx
+++ b/src/app/Instance/DeleteInstance/DeleteInstance.tsx
@@ -6,10 +6,10 @@ import { useTranslation } from "react-i18next";
 import axios from "axios";
 import {
   getErrorCode,
+  getErrorReason,
   isServiceApiError,
 } from "@openapi/generated/errorHelpers";
 import { APIErrorCodes } from "@openapi/generated/errors";
-import { ResponseError } from "../../../types/Error";
 import { useHistory } from "react-router-dom";
 
 interface DeleteInstanceProps {
@@ -101,8 +101,7 @@ const DeleteInstance = (props: DeleteInstanceProps): JSX.Element => {
         getErrorCode(bridgeDeleteError) === APIErrorCodes.ERROR_2
       ) {
         setDeleteBlockedReason(
-          (bridgeDeleteError.response?.data as ResponseError)?.reason ??
-            genericErrorMsg
+          getErrorReason(bridgeDeleteError) ?? genericErrorMsg
         );
         shouldRedirectToHome.current = true;
       } else if (

--- a/src/app/Processor/DeleteProcessor/DeleteProcessor.tsx
+++ b/src/app/Processor/DeleteProcessor/DeleteProcessor.tsx
@@ -65,7 +65,7 @@ const DeleteProcessor = (props: DeleteProcessorProps): JSX.Element => {
       const genericErrorMsg = t("processor.errors.cantDeleteTryLater");
       if (
         isServiceApiError(error) &&
-        getErrorCode(error) === APIErrorCodes.ERROR_2
+        getErrorCode(error) === APIErrorCodes.ERROR_19
       ) {
         setDeleteBlockedReason(getErrorReason(error) ?? genericErrorMsg);
       } else if (

--- a/src/app/Processor/DeleteProcessor/DeleteProcessor.tsx
+++ b/src/app/Processor/DeleteProcessor/DeleteProcessor.tsx
@@ -5,10 +5,10 @@ import { useTranslation } from "react-i18next";
 import axios from "axios";
 import {
   getErrorCode,
+  getErrorReason,
   isServiceApiError,
 } from "@openapi/generated/errorHelpers";
 import { APIErrorCodes } from "@openapi/generated/errors";
-import { ResponseError } from "../../../types/Error";
 
 interface DeleteProcessorProps {
   /** Flag to show/close the modal */
@@ -67,9 +67,7 @@ const DeleteProcessor = (props: DeleteProcessorProps): JSX.Element => {
         isServiceApiError(error) &&
         getErrorCode(error) === APIErrorCodes.ERROR_2
       ) {
-        setDeleteBlockedReason(
-          (error.response?.data as ResponseError)?.reason ?? genericErrorMsg
-        );
+        setDeleteBlockedReason(getErrorReason(error) ?? genericErrorMsg);
       } else if (
         isServiceApiError(error) &&
         getErrorCode(error) === APIErrorCodes.ERROR_4


### PR DESCRIPTION
As follow up of https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox-ui/pull/91 we are going to provide a utility function for retrieving the `reason` field from the first error item and using it in the delete modals.