### PR TITLE
MGDOBR-872: Manage masked values inside action/source configuration

### DIFF
--- a/cypress/integration/ActionTest.ts
+++ b/cypress/integration/ActionTest.ts
@@ -184,7 +184,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         pageWasLoaded();
       });
 
-      it("The editing is allowed, except for the processor name", () => {
+      it("The editing is partially allowed", () => {
         const configOuiaId = [
           "slack_channel",
           "slack_webhook_url",
@@ -194,7 +194,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         ];
         cy.ouiaId("edit", "PF4/Button").click();
         cy.ouiaId("processor-name", "PF4/TextInput").should("be.disabled");
-        cy.ouiaId("action-type", "PF4/FormSelect").should("be.enabled");
+        cy.ouiaId("action-type", "PF4/FormSelect").should("be.disabled");
         cy.ouiaId("actions", "form-section").within(() => {
           cy.ouiaType("config-parameter").should(
               "have.length",

--- a/cypress/integration/ActionTest.ts
+++ b/cypress/integration/ActionTest.ts
@@ -197,15 +197,15 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         cy.ouiaId("action-type", "PF4/FormSelect").should("be.disabled");
         cy.ouiaId("actions", "form-section").within(() => {
           cy.ouiaType("config-parameter").should(
-              "have.length",
-              configOuiaId.length
+            "have.length",
+            configOuiaId.length
           );
           configOuiaId.forEach((ouiaId) => {
             cy.ouiaId(ouiaId, "config-parameter")
-                .find("input")
-                .scrollIntoView()
-                .should("be.visible")
-                .should("be.enabled");
+              .find("input")
+              .scrollIntoView()
+              .should("be.visible")
+              .should("be.enabled");
           });
         });
       });

--- a/cypress/integration/ActionTest.ts
+++ b/cypress/integration/ActionTest.ts
@@ -184,7 +184,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         pageWasLoaded();
       });
 
-      it("The editation is not allowed", () => {
+      it("The editing is allowed, except for the processor name", () => {
         const configOuiaId = [
           "slack_channel",
           "slack_webhook_url",
@@ -193,18 +193,19 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
           "slack_username",
         ];
         cy.ouiaId("edit", "PF4/Button").click();
-        cy.ouiaId("action-type", "PF4/FormSelect").should("be.disabled");
+        cy.ouiaId("processor-name", "PF4/TextInput").should("be.disabled");
+        cy.ouiaId("action-type", "PF4/FormSelect").should("be.enabled");
         cy.ouiaId("actions", "form-section").within(() => {
           cy.ouiaType("config-parameter").should(
-            "have.length",
-            configOuiaId.length
+              "have.length",
+              configOuiaId.length
           );
           configOuiaId.forEach((ouiaId) => {
             cy.ouiaId(ouiaId, "config-parameter")
-              .find("input")
-              .scrollIntoView()
-              .should("be.visible")
-              .should("be.disabled");
+                .find("input")
+                .scrollIntoView()
+                .should("be.visible")
+                .should("be.enabled");
           });
         });
       });

--- a/cypress/integration/SourceTest.ts
+++ b/cypress/integration/SourceTest.ts
@@ -203,15 +203,15 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         cy.ouiaId("source-type", "PF4/FormSelect").should("be.disabled");
         cy.ouiaId("sources", "form-section").within(() => {
           cy.ouiaType("config-parameter").should(
-              "have.length",
-              configOuiaId.length
+            "have.length",
+            configOuiaId.length
           );
           configOuiaId.forEach((ouiaId) => {
             cy.ouiaId(ouiaId, "config-parameter")
-                .find("input")
-                .scrollIntoView()
-                .should("be.visible")
-                .should("be.enabled");
+              .find("input")
+              .scrollIntoView()
+              .should("be.visible")
+              .should("be.enabled");
           });
         });
       });

--- a/cypress/integration/SourceTest.ts
+++ b/cypress/integration/SourceTest.ts
@@ -191,7 +191,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         pageWasLoaded();
       });
 
-      it("The editation is not allowed", () => {
+      it("The editing is allowed, except for the processor name", () => {
         const configOuiaId = [
           "slack_channel",
           "slack_token",
@@ -199,18 +199,19 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
           "kafka_topic",
         ];
         cy.ouiaId("edit", "PF4/Button").click();
-        cy.ouiaId("source-type", "PF4/FormSelect").should("be.disabled");
+        cy.ouiaId("processor-name", "PF4/TextInput").should("be.disabled");
+        cy.ouiaId("source-type", "PF4/FormSelect").should("be.enabled");
         cy.ouiaId("sources", "form-section").within(() => {
           cy.ouiaType("config-parameter").should(
-            "have.length",
-            configOuiaId.length
+              "have.length",
+              configOuiaId.length
           );
           configOuiaId.forEach((ouiaId) => {
             cy.ouiaId(ouiaId, "config-parameter")
-              .find("input")
-              .scrollIntoView()
-              .should("be.visible")
-              .should("be.disabled");
+                .find("input")
+                .scrollIntoView()
+                .should("be.visible")
+                .should("be.enabled");
           });
         });
       });

--- a/cypress/integration/SourceTest.ts
+++ b/cypress/integration/SourceTest.ts
@@ -191,7 +191,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         pageWasLoaded();
       });
 
-      it("The editing is allowed, except for the processor name", () => {
+      it("The editing is partially allowed", () => {
         const configOuiaId = [
           "slack_channel",
           "slack_token",
@@ -200,7 +200,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         ];
         cy.ouiaId("edit", "PF4/Button").click();
         cy.ouiaId("processor-name", "PF4/TextInput").should("be.disabled");
-        cy.ouiaId("source-type", "PF4/FormSelect").should("be.enabled");
+        cy.ouiaId("source-type", "PF4/FormSelect").should("be.disabled");
         cy.ouiaId("sources", "form-section").within(() => {
           cy.ouiaType("config-parameter").should(
               "have.length",

--- a/locales/en/openbridge.json
+++ b/locales/en/openbridge.json
@@ -91,6 +91,7 @@
     "channel": "Channel",
     "commaSeparatedValuesTooltip": "For this filter type, it is necessary to specify a list of values separated by a comma.",
     "createProcessor": "Create processor",
+    "credentialEditFieldHelpText": "This field is a credential and its value cannot be displayed. Entering a new value will update the processor configuration.",
     "delete": "Delete processor",
     "deleteFilter": "Delete filter",
     "deleteProcessor": "Delete Processor?",

--- a/mocked-api/data.ts
+++ b/mocked-api/data.ts
@@ -160,8 +160,7 @@ export const processorData = [
       type: "slack_sink_0.1",
       parameters: JSON.stringify({
         slack_channel: "#test",
-        slack_webhook_url:
-          "https://hooks.slack.com/services/XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXX",
+        slack_webhook_url: {},
         slack_username: "test",
       }),
     },
@@ -186,8 +185,7 @@ export const processorData = [
       type: "slack_sink_0.1",
       parameters: JSON.stringify({
         slack_channel: "test",
-        slack_webhook_url:
-          "https://hooks.slack.com/services/XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXX",
+        slack_webhook_url: {},
       }),
     },
   },
@@ -211,7 +209,7 @@ export const processorData = [
       type: "slack_source_0.1",
       parameters: JSON.stringify({
         slack_channel: "#test",
-        slack_token: "***********",
+        slack_token: {},
       }),
     },
   },
@@ -229,7 +227,7 @@ export const processorData = [
       type: "slack_source_0.1",
       parameters: JSON.stringify({
         slack_channel: "#test",
-        slack_token: "***********",
+        slack_token: {},
       }),
     },
   },

--- a/mocked-api/schemasData.ts
+++ b/mocked-api/schemasData.ts
@@ -131,10 +131,22 @@ export const schemasData: { [key: string]: object } = {
         example: "kermit",
       },
       basic_auth_password: {
-        type: "string",
         title: "Basic Auth Password",
-        description: "The password for basic auth.",
-        example: "mypassword",
+        "x-group": "credentials",
+        oneOf: [
+          {
+            title: "Basic Auth Password",
+            description: "The password for basic auth.",
+            type: "string",
+            format: "password",
+            example: "mypassword",
+          },
+          {
+            description: "An opaque reference to the basic_auth_password",
+            type: "object",
+            properties: {},
+          },
+        ],
       },
       ssl_verification_disabled: {
         type: "boolean",
@@ -177,10 +189,22 @@ export const schemasData: { [key: string]: object } = {
           "The Client Id part of the credentials to authenticate to Kafka",
       },
       kafka_client_secret: {
-        type: "string",
         title: "Client Secret",
-        description:
-          "The Client Secret part of the credentials to authenticate to Kafka",
+        "x-group": "credentials",
+        oneOf: [
+          {
+            title: "Client Secret",
+            description:
+              "The Client Secret part of the credentials to authenticate to Kafka",
+            type: "string",
+            format: "password",
+          },
+          {
+            description: "An opaque reference to the kafka_client_secret",
+            type: "object",
+            properties: {},
+          },
+        ],
       },
     },
     required: [
@@ -273,14 +297,24 @@ export const schemasData: { [key: string]: object } = {
         title: "Basic Auth Username",
         description: "The username for basic auth.",
         example: "kermit",
-        format: "password",
       },
       basic_auth_password: {
-        type: "string",
         title: "Basic Auth Password",
-        description: "The password for basic auth.",
-        example: "mypassword",
-        format: "password",
+        "x-group": "credentials",
+        oneOf: [
+          {
+            title: "Basic Auth Password",
+            description: "The password for basic auth.",
+            type: "string",
+            format: "password",
+            example: "mypassword",
+          },
+          {
+            description: "An opaque reference to the basic_auth_password",
+            type: "object",
+            properties: {},
+          },
+        ],
       },
       ssl_verification_disabled: {
         type: "boolean",

--- a/src/app/Instance/CreateInstance/CreateInstance.test.tsx
+++ b/src/app/Instance/CreateInstance/CreateInstance.test.tsx
@@ -24,7 +24,7 @@ const setupCreateInstance = (
         resolve([cloudRegion]);
       }),
     createBridgeError,
-    getSchema = props.getSchema ?? jest.fn(),
+    getSchema = jest.fn(),
   } = props;
 
   const comp = customRender(
@@ -133,8 +133,6 @@ describe("CreateInstance component", () => {
     expect(
       comp.baseElement.querySelector("button#cloud-region")
     ).toHaveTextContent(cloudRegion.display_name);
-
-    await waitFor(() => {});
   });
 
   it("should create an instance when a name is provided", async () => {

--- a/src/app/Instance/CreateInstance/CreateInstance.tsx
+++ b/src/app/Instance/CreateInstance/CreateInstance.tsx
@@ -277,7 +277,7 @@ const CreateInstance = (props: CreateInstanceProps): JSX.Element => {
   }, [cloudRegions, cloudProviders]);
 
   useEffect(() => {
-    setErrorHandlingSchema({});
+    setErrorHandlingSchema(undefined);
     if (errorHandlingSchemaId) {
       setErrorHandlingSchemaLoading(true);
       getSchema(errorHandlingSchemaId, ProcessorSchemaType.ACTION)
@@ -450,6 +450,7 @@ const CreateInstance = (props: CreateInstanceProps): JSX.Element => {
               }}
               registerValidation={registerValidateParameters}
               readOnly={formIsDisabled}
+              editMode={false}
             />
           )}
         </FormSection>

--- a/src/app/Processor/CreateProcessorPage/CreateProcessorPage.tsx
+++ b/src/app/Processor/CreateProcessorPage/CreateProcessorPage.tsx
@@ -204,6 +204,7 @@ const CreateProcessorPage = (): JSX.Element => {
             malformedTransformationTemplate={malformedTemplate}
             schemaCatalog={schemas}
             getSchema={getSchema}
+            goBackToInstance={goToInstance}
           />
         </>
       )}

--- a/src/app/Processor/ProcessorDetail/ProcessorDetail.test.tsx
+++ b/src/app/Processor/ProcessorDetail/ProcessorDetail.test.tsx
@@ -10,6 +10,7 @@ import {
   ManagedResourceStatus,
   ProcessorType,
 } from "@rhoas/smart-events-management-sdk";
+import { maskedValue } from "@app/Processor/ProcessorDetail/ProcessorDetailConfigParameters";
 
 describe("ProcessorDetail component", () => {
   it("should display sink processor information", async () => {
@@ -62,12 +63,7 @@ describe("ProcessorDetail component", () => {
           .slack_channel as string
       )
     ).toBeInTheDocument();
-    expect(
-      comp.queryByText(
-        (sinkProcessor.action.parameters as { [key: string]: unknown })
-          .slack_webhook_url as string
-      )
-    ).toBeInTheDocument();
+    expect(comp.queryByText(maskedValue)).toBeInTheDocument();
 
     expect(
       comp.queryByText(
@@ -122,12 +118,7 @@ describe("ProcessorDetail component", () => {
       )
     ).toBeInTheDocument();
 
-    expect(
-      comp.queryByText(
-        (sourceProcessor.source.parameters as { [key: string]: unknown })
-          .slack_token as string
-      )
-    ).toBeInTheDocument();
+    expect(comp.queryByText(maskedValue)).toBeInTheDocument();
     expect(
       comp.queryByText(
         (sourceProcessor.source.parameters as { [key: string]: unknown })

--- a/src/app/Processor/ProcessorDetail/ProcessorDetailConfigParameters.tsx
+++ b/src/app/Processor/ProcessorDetail/ProcessorDetailConfigParameters.tsx
@@ -11,6 +11,7 @@ import {
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
 import { useTranslation } from "react-i18next";
 import { DataShapeValue } from "../../../types/Processor";
+import { isJSONSchema } from "@utils/processorUtils";
 
 interface ProcessorDetailConfigParametersProps {
   schema: JSONSchema7;
@@ -156,9 +157,11 @@ const displayFieldValue = (
           const passwordField = oneOf.filter(
             (item) => typeof item !== "boolean" && item?.format === "password"
           );
-          if (passwordField && typeof value === "string") {
+          if (passwordField) {
             return (
-              <DescriptionListDescription>{value}</DescriptionListDescription>
+              <DescriptionListDescription>
+                {maskedValue}
+              </DescriptionListDescription>
             );
           }
         }
@@ -182,6 +185,4 @@ export const DataShape = ({ data }: { data: DataShapeValue }): JSX.Element => {
   );
 };
 
-const isJSONSchema = (value: JSONSchema7Definition): value is JSONSchema7 => {
-  return typeof value !== "boolean";
-};
+export const maskedValue = "**************************";

--- a/src/app/Processor/ProcessorEdit/ConfigurationEdit/ConfigurationEdit.tsx
+++ b/src/app/Processor/ProcessorEdit/ConfigurationEdit/ConfigurationEdit.tsx
@@ -118,7 +118,7 @@ const ConfigurationEdit = (props: ConfigurationEditProps): JSX.Element => {
           value={type}
           onChange={(type: string): void => updateType(type)}
           validated={typeValidation === false ? "error" : "default"}
-          isDisabled={readOnly}
+          isDisabled={readOnly || editMode}
         >
           {typeOptions.map((option, index) => (
             <FormSelectOption

--- a/src/app/Processor/ProcessorEdit/ConfigurationForm/ConfigurationForm.tsx
+++ b/src/app/Processor/ProcessorEdit/ConfigurationForm/ConfigurationForm.tsx
@@ -58,24 +58,28 @@ const ConfigurationForm = (props: ConfigurationFormProps): JSX.Element => {
   }, [registerValidation, validate]);
 
   return (
-    <DynamicForm
-      validate={"onChangeAfterSubmit"}
-      schema={bridge}
-      model={convertedConfiguration}
-      onChangeModel={onChange}
-      ref={(ref: any): void => (newRef.current = ref)}
-      disabled={readOnly}
-    >
-      {Object.keys(properties as { [key: string]: unknown }).map((key) => (
-        <AutoField
-          key={key}
-          name={key}
+    <>
+      {properties && (
+        <DynamicForm
+          validate={"onChangeAfterSubmit"}
+          schema={bridge}
+          model={convertedConfiguration}
+          onChangeModel={onChange}
+          ref={(ref: any): void => (newRef.current = ref)}
           disabled={readOnly}
-          data-ouia-component-id={key}
-          data-ouia-component-type="config-parameter"
-        />
-      ))}
-    </DynamicForm>
+        >
+          {Object.keys(properties as { [key: string]: unknown }).map((key) => (
+            <AutoField
+              key={key}
+              name={key}
+              disabled={readOnly}
+              data-ouia-component-id={key}
+              data-ouia-component-type="config-parameter"
+            />
+          ))}
+        </DynamicForm>
+      )}
+    </>
   );
 };
 

--- a/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
+++ b/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
@@ -74,7 +74,7 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
         ...(this.showCredentialHelpText && {
           helperText: this.duplicateMode
             ? this.t("credentialDuplicateFieldHelpText")
-            : this.t("credentialEditFieldHelpText"),
+            : this.t("processor.credentialEditFieldHelpText"),
         }),
         labelIcon: getLabelIcon(label || name, description),
         name,

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -1,6 +1,8 @@
 import { EventFilter, FilterType } from "../types/Processor";
 
-export const isCommaSeparatedFilterType = (filter: EventFilter): boolean => {
+export const isCommaSeparatedFilterType = (
+  filter: Partial<EventFilter>
+): boolean => {
   return [FilterType.STRING_IN, FilterType.NUMBER_IN].includes(
     filter.type as FilterType
   );

--- a/src/utils/processorUtils.test.ts
+++ b/src/utils/processorUtils.test.ts
@@ -6,7 +6,7 @@ import {
   resolveReference,
 } from "@utils/processorUtils";
 import { JSONSchema7 } from "json-schema";
-import { ProcessorType } from "@openapi/generated";
+import { ProcessorType } from "@rhoas/smart-events-management-sdk";
 import omit from "lodash.omit";
 
 describe("prepareConfigParameters", () => {

--- a/src/utils/processorUtils.test.ts
+++ b/src/utils/processorUtils.test.ts
@@ -1,0 +1,431 @@
+import {
+  getSchemaDefinition,
+  prepareConfigParameters,
+  prepareFilters,
+  prepareRequest,
+  resolveReference,
+} from "@utils/processorUtils";
+import { JSONSchema7 } from "json-schema";
+import { ProcessorType } from "@openapi/generated";
+import omit from "lodash.omit";
+
+describe("prepareConfigParameters", () => {
+  it("converts secret parameters values to empty strings in order to use them inside the processor form", () => {
+    const configParameters = {
+      slack_channel: "#test",
+      slack_token: {},
+    };
+
+    const convertedParameters = prepareConfigParameters(
+      configParameters,
+      demoSchema,
+      "read"
+    );
+
+    expect(convertedParameters).toStrictEqual({
+      // non-secret fields values are untouched
+      ...configParameters,
+      // slack token converted to empty string because
+      // of its "password" definition inside the schema
+      slack_token: "",
+    });
+  });
+
+  it("converts secret parameters from empty strings to empty objects (secret format)", () => {
+    const configParameters = {
+      slack_channel: "#test",
+      slack_token: "",
+    };
+
+    const convertedParameters = prepareConfigParameters(
+      configParameters,
+      demoSchema,
+      "write"
+    );
+
+    expect(convertedParameters).toStrictEqual({
+      ...configParameters,
+      // slack token has not been set, so it will be converted back into
+      // an empty object
+      slack_token: {},
+    });
+  });
+
+  it("doesn't alter secret values when they are not empty", () => {
+    const configParameters = {
+      slack_channel: "#test",
+      slack_token: "test-value",
+    };
+
+    const convertedParameters = prepareConfigParameters(
+      configParameters,
+      demoSchema,
+      "write"
+    );
+    // non-empty secret parameters are not converted to empty objects (editing existing processor scenario and
+    // overwriting a secret field with a new value)
+    expect(convertedParameters).toStrictEqual(configParameters);
+  });
+
+  it("converts empty strings to empty objects only if the parameter is defined as secret within the schema", () => {
+    const configParameters = {
+      slack_channel: "#test",
+      slack_token: "",
+    };
+
+    const convertedParameters = prepareConfigParameters(
+      configParameters,
+      demoSchemaNoPassword,
+      "write"
+    );
+
+    // no changes from the input parameters. slack_token is not converted to an empty object because
+    // it's not defined with a password format in the schema
+    expect(convertedParameters).toStrictEqual(configParameters);
+  });
+});
+
+describe("getSchemaDefinition", () => {
+  it("retrieves a property definition from a json-schema", () => {
+    const definition = getSchemaDefinition("slack_token", demoSchema);
+    expect(definition).toStrictEqual(demoSchema?.properties?.slack_token);
+  });
+
+  it("retrieves the definition of a property described in a sub-schema", () => {
+    const definition = getSchemaDefinition(
+      "data_shape.consumes.format",
+      schemaWithDef as JSONSchema7
+    );
+    expect(definition).toStrictEqual(
+      schemaWithDef.$defs.data_shape.consumes.properties.format
+    );
+  });
+
+  it("returns 'undefined' for not found properties", () => {
+    const definition = getSchemaDefinition(
+      "not_existing",
+      schemaWithDef as JSONSchema7
+    );
+    expect(definition).toBeUndefined();
+  });
+});
+
+describe("resolveReference", () => {
+  it("retrieves a sub-schema reference defined inside the same json-schema file", () => {
+    const def = resolveReference(
+      "#/$defs/data_shape/consumes",
+      schemaWithDef as JSONSchema7
+    );
+    expect(def).toBe(schemaWithDef.$defs.data_shape.consumes);
+  });
+
+  it("returns undefined if the reference is not found", () => {
+    const def = resolveReference(
+      "#/$defs/not_existing/consumes",
+      schemaWithDef as JSONSchema7
+    );
+    expect(def).toBeUndefined();
+  });
+});
+
+describe("prepareFilters", () => {
+  it("keeps a filter when all the properties are present", () => {
+    const basicFilter = {
+      key: "name",
+      type: "StringEquals",
+      value: "test",
+    };
+
+    const result = prepareFilters([basicFilter]);
+    expect(result).toHaveLength(1);
+    expect(result).toStrictEqual([basicFilter]);
+  });
+
+  it("skips filters with missing properties", () => {
+    const result1 = prepareFilters([{ key: "name" }]);
+    expect(result1).toHaveLength(0);
+
+    const result2 = prepareFilters([{ type: "NumberIn" }]);
+    expect(result2).toHaveLength(0);
+
+    const result3 = prepareFilters([{ value: "one, two" }]);
+    expect(result3).toHaveLength(0);
+
+    const result4 = prepareFilters([
+      {
+        key: "name",
+        type: "NumberIn",
+      },
+    ]);
+    expect(result4).toHaveLength(0);
+  });
+
+  it("converts a StringIn filter", () => {
+    const validFilter = {
+      key: "name",
+      type: "StringIn",
+      value: "one, two, three",
+    };
+
+    const result = prepareFilters([validFilter]);
+    const { key, type } = validFilter;
+    expect(result).toHaveLength(1);
+    expect(result).toStrictEqual([
+      {
+        key,
+        type,
+        values: validFilter.value.split(",").map((item) => item.trim()),
+      },
+    ]);
+  });
+
+  it("converts NumberIn filters when the values are valid", () => {
+    const validFilter = {
+      key: "name",
+      type: "NumberIn",
+      value: "1, 2, 3",
+    };
+
+    const result = prepareFilters([validFilter]);
+    const { key, type } = validFilter;
+    expect(result).toHaveLength(1);
+    expect(result).toStrictEqual([
+      {
+        key,
+        type,
+        values: validFilter.value
+          .split(",")
+          .map((item) => parseFloat(item.trim())),
+      },
+    ]);
+  });
+
+  it("skips NumberIn filters when the values are not numbers", () => {
+    const validFilter = {
+      key: "name",
+      type: "NumberIn",
+      value: "one, two, three",
+    };
+
+    const result = prepareFilters([validFilter]);
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("prepareRequest", () => {
+  it("correctly includes only relevant properties for a sink processor", () => {
+    const processorData = {
+      ...baseProcessorFormData,
+      type: ProcessorType.Sink,
+      action: {
+        type: "slack",
+        parameters: {
+          slack_token: "token",
+          slack_channel: "#test",
+        },
+      },
+    };
+
+    const result = prepareRequest(processorData, false, demoSchema);
+    // properties not included are empty ones ("filters", "transformation"), not valid for the
+    // current type ("source" within sink processor in this case) and not requested ones ("type")
+    expect(result).toStrictEqual(
+      omit(processorData, [
+        "source",
+        "filters",
+        "transformationTemplate",
+        "type",
+      ])
+    );
+  });
+
+  it("correctly includes only relevant properties for a source processor", () => {
+    const processorData = {
+      ...baseProcessorFormData,
+      type: ProcessorType.Source,
+      source: {
+        type: "slack",
+        parameters: {
+          slack_token: "token",
+          slack_channel: "#test",
+        },
+      },
+    };
+
+    const result = prepareRequest(processorData, false, demoSchema);
+    // "action" property is skipped, "source" is kept
+    expect(result).toStrictEqual(
+      omit(processorData, [
+        "action",
+        "filters",
+        "transformationTemplate",
+        "type",
+      ])
+    );
+  });
+
+  it("correctly includes optional properties only when they contain values", () => {
+    const processorData = {
+      ...baseProcessorFormData,
+      type: ProcessorType.Source,
+      source: {
+        type: "slack",
+        parameters: {
+          slack_token: "token",
+          slack_channel: "#test",
+        },
+      },
+      filters: [{ key: "name", type: "StringEquals", value: "test" }],
+      transformationTemplate: "hello",
+    };
+
+    const result = prepareRequest(processorData, false, demoSchema);
+    // transformation template and filters are kept
+    expect(result).toStrictEqual(omit(processorData, ["action", "type"]));
+  });
+
+  it("takes care of converting empty secret parameters when editing an existing processor", () => {
+    const processorData = {
+      ...baseProcessorFormData,
+      type: ProcessorType.Source,
+      source: {
+        type: "slack",
+        parameters: {
+          slack_token: "",
+          slack_channel: "#test",
+        },
+      },
+    };
+
+    const result = prepareRequest(processorData, true, demoSchema);
+    const expectedRequestData = {
+      ...omit(processorData, [
+        "action",
+        "type",
+        "filters",
+        "transformationTemplate",
+      ]),
+      source: {
+        ...processorData.source,
+        // the empty "slack_token" is converted back to an empty object
+        parameters: { ...processorData.source.parameters, slack_token: {} },
+      },
+    };
+    expect(result).toStrictEqual(expectedRequestData);
+  });
+});
+
+const demoSchema: JSONSchema7 = {
+  type: "object",
+  additionalProperties: false,
+  required: ["slack_channel", "slack_token"],
+  properties: {
+    slack_channel: {
+      title: "Channel",
+      description: "The Slack channel to receive messages from",
+      type: "string",
+    },
+    slack_token: {
+      title: "Token",
+      oneOf: [
+        {
+          title: "Token",
+          description:
+            "The token to access Slack. A Slack app is needed. This app needs to have channels:history and channels:read permissions. The Bot User OAuth Access Token is the kind of token needed.",
+          type: "string",
+          format: "password",
+        },
+        {
+          description: "An opaque reference to the slack_token",
+          type: "object",
+          properties: {},
+        },
+      ],
+    },
+  },
+};
+
+const demoSchemaNoPassword = {
+  ...demoSchema,
+  properties: {
+    ...demoSchema.properties,
+    slack_token: {
+      title: "Token",
+      description: "The token to access Slack.",
+      type: "string",
+    },
+  },
+};
+
+const schemaWithDef = {
+  type: "object",
+  additionalProperties: false,
+  required: ["slack_channel", "slack_webhook_url"],
+  properties: {
+    slack_channel: {
+      title: "Channel",
+      description: "The Slack channel to send messages to.",
+      type: "string",
+      example: "#myroom",
+    },
+    slack_webhook_url: {
+      title: "Webhook URL",
+      "x-group": "credentials",
+      oneOf: [
+        {
+          title: "Webhook URL",
+          description:
+            "The webhook URL used by the Slack channel to handle incoming messages.",
+          type: "string",
+          format: "password",
+        },
+        {
+          description: "An opaque reference to the slack_webhook_url",
+          type: "object",
+          properties: {},
+        },
+      ],
+    },
+    data_shape: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        consumes: {
+          $ref: "#/$defs/data_shape/consumes",
+        },
+      },
+    },
+    processors: {},
+  },
+  $defs: {
+    data_shape: {
+      consumes: {
+        type: "object",
+        additionalProperties: false,
+        required: ["format"],
+        properties: {
+          format: {
+            type: "string",
+            default: "application/octet-stream",
+            enum: ["application/octet-stream"],
+          },
+        },
+      },
+    },
+  },
+};
+
+const baseProcessorFormData = {
+  name: "test",
+  filters: [{ key: "", type: "", value: "" }],
+  transformationTemplate: "",
+  action: {
+    type: "",
+    parameters: {},
+  },
+  source: {
+    type: "",
+    parameters: {},
+  },
+};

--- a/src/utils/processorUtils.ts
+++ b/src/utils/processorUtils.ts
@@ -1,0 +1,229 @@
+import { ProcessorRequest, ProcessorType, Source } from "@openapi/generated";
+import { EventFilter, FilterType, ProcessorFormData } from "../types/Processor";
+import { isCommaSeparatedFilterType } from "@utils/filterUtils";
+import { JSONSchema7, JSONSchema7Definition } from "json-schema";
+
+/**
+ * Prepare configuration params before reading and writing them.
+ * Its only purpose is to manage secret fields and convert to and from
+ * their masked value (empty object: {})
+ * @param data The configuration params object
+ * @param schema The json schema object
+ * @param mode "read" when retrieving data, "write" when preparing data for a save request
+ * @param [parentKey] Key of the parent configuration parameter used when drilling nested data
+ */
+export const prepareConfigParameters = (
+  data: object,
+  schema: object,
+  mode: "read" | "write",
+  parentKey?: string
+): Source["parameters"] => {
+  const newParams: { [key: string]: unknown } = {};
+  const secretNewValue = (value: unknown): unknown => {
+    if (mode === "read") {
+      return typeof value === "object" ? "" : value;
+    }
+    return value === "" ? {} : value;
+  };
+
+  Object.keys(data).map((key) => {
+    const value = (data as { [key: string]: unknown })[key];
+    if (value !== null) {
+      if (typeof value === "object" && Object.keys(value).length > 0) {
+        newParams[key] = prepareConfigParameters(
+          value,
+          schema,
+          mode,
+          parentKey ? `${parentKey}.${key}` : key
+        );
+      } else {
+        if (schema) {
+          const def = getSchemaDefinition(
+            parentKey ? `${parentKey}.${key}` : key,
+            schema
+          );
+          if (def && isJSONSchema(def)) {
+            const { oneOf } = def;
+            if (
+              oneOf &&
+              oneOf.filter(
+                (item) => isJSONSchema(item) && item?.format === "password"
+              ).length > 0
+            ) {
+              newParams[key] = secretNewValue(value);
+            } else {
+              newParams[key] = value;
+            }
+          } else {
+            newParams[key] = value;
+          }
+        }
+      }
+    }
+  });
+  return newParams;
+};
+
+/**
+ * Prepare processor filters data to be included in a processors API request
+ * Filters with invalid or missing properties are excluded from requests
+ * @param filters The filters produced by the processors form
+ */
+export const prepareFilters = (
+  filters: Partial<EventFilter>[]
+): Partial<EventFilter>[] =>
+  filters
+    .filter(
+      (filter) => filter.type && (filter.value || filter.values) && filter.key
+    )
+    .map((filter) => {
+      if (filter.value && isCommaSeparatedFilterType(filter)) {
+        const multipleValuesMapper = (item: string): number | string =>
+          filter.type === FilterType.NUMBER_IN
+            ? parseFloat(item.trim())
+            : item.trim();
+
+        const multipleValuesPredicate =
+          filter.type === FilterType.NUMBER_IN
+            ? (item: number | string): boolean =>
+                item !== null && !isNaN(item as number)
+            : String;
+
+        const values = filter.value
+          .split(",")
+          .map(multipleValuesMapper)
+          .filter(multipleValuesPredicate);
+
+        return {
+          key: filter.key,
+          type: filter.type,
+          values,
+        };
+      }
+      return filter;
+    })
+    .filter(
+      (item: Partial<EventFilter>) =>
+        item.value || (item.values && item.values.length > 0)
+    );
+
+/**
+ * Cleanup and prepare processor form data before sending it to an API request
+ * @param formData Data coming from the processor form
+ * @param isExistingProcessor Flag indicating if it's a new processor or an update
+ * @param schema The json-schema of the action/source configuration used in the processor
+ */
+export const prepareRequest = (
+  formData: ProcessorFormData,
+  isExistingProcessor: boolean,
+  schema: object
+): ProcessorRequest => {
+  const requestData: ProcessorRequest = { name: formData.name };
+  if (formData.type === ProcessorType.Sink) {
+    requestData.action =
+      isExistingProcessor && formData.action && schema
+        ? {
+            type: formData.action.type,
+            parameters: prepareConfigParameters(
+              formData.action.parameters,
+              schema,
+              "write"
+            ),
+          }
+        : formData.action;
+  } else {
+    requestData.source =
+      isExistingProcessor && formData.source && schema
+        ? {
+            type: formData.source.type,
+            parameters: prepareConfigParameters(
+              formData.source.parameters,
+              schema,
+              "write"
+            ),
+          }
+        : formData.source;
+  }
+  if (formData.filters && formData.filters.length > 0) {
+    const filtersData = prepareFilters(formData.filters) as EventFilter[];
+    if (filtersData.length > 0) {
+      requestData.filters =
+        filtersData as unknown as ProcessorRequest["filters"];
+    }
+  }
+  if (
+    formData.transformationTemplate &&
+    formData.transformationTemplate.trim().length > 0
+  ) {
+    requestData.transformationTemplate = formData.transformationTemplate.trim();
+  }
+  return requestData;
+};
+
+/**
+ * Retrieve the definition of a specific property inside a json schema
+ * @param propertyName Name of the property
+ * @param schema Json schema object
+ * @param [parentSchema] Parent schema object used when drilling down nested fields
+ */
+export const getSchemaDefinition = (
+  propertyName: string,
+  schema: JSONSchema7,
+  parentSchema?: JSONSchema7
+): JSONSchema7Definition | undefined => {
+  if (schema.properties) {
+    const propertySplit = propertyName.split(".");
+    const currentProperty = propertySplit.shift();
+
+    if (currentProperty) {
+      const prop = schema.properties[currentProperty];
+      if (typeof prop === "undefined" || !isJSONSchema(prop)) {
+        return undefined;
+      }
+      const definition: JSONSchema7Definition = prop.$ref
+        ? resolveReference(prop.$ref, parentSchema ?? schema)
+        : prop;
+
+      if (isJSONSchema(definition)) {
+        if (definition.type === "object" && definition.properties) {
+          return getSchemaDefinition(
+            propertySplit.join("."),
+            definition,
+            schema
+          );
+        }
+        return definition;
+      }
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Check if a json schema definition is a json schema and not a boolean
+ * @param value The json schema definition to check
+ */
+export const isJSONSchema = (
+  value: JSONSchema7Definition
+): value is JSONSchema7 => {
+  return typeof value !== "boolean";
+};
+
+/**
+ * Simple reference resolver that works with basic references contained in the
+ * same schema object
+ * @param ref
+ * @param schema
+ */
+export const resolveReference = (
+  ref: string,
+  schema: JSONSchema7
+): JSONSchema7Definition => {
+  const allButFirst = ref.split("/");
+  allButFirst.shift();
+  return allButFirst.reduce(
+    (prev, key) =>
+      prev && ((prev as { [key: string]: unknown })[key] as JSONSchema7),
+    schema
+  );
+};

--- a/src/utils/processorUtils.ts
+++ b/src/utils/processorUtils.ts
@@ -1,4 +1,8 @@
-import { ProcessorRequest, ProcessorType, Source } from "@openapi/generated";
+import {
+  ProcessorRequest,
+  ProcessorType,
+  Source,
+} from "@rhoas/smart-events-management-sdk";
 import { EventFilter, FilterType, ProcessorFormData } from "../types/Processor";
 import { isCommaSeparatedFilterType } from "@utils/filterUtils";
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-872

This PR depends on:

- https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox/pull/863

I'm adding support for the new format of masked values (empty object, `{}`) inside processors.

To test this you will have to check your browser developer tools console and inspect network requests.

Steps to test it:
- `npm run start:mocked` (until the related PR is merged, you can only use the mocked APIs)
- open a bridge and click on create new processor
- select the sink type
- provide a processor name
- select an action with sensitive fields (like `AWS Lambda`)
- fill up the action configuration parameters
- click on the create processor button
- inspect the payload of the POST request that creates the processor. It will include the sensitive fields values as you provided them
- in the processors list page, wait until the new processor gets `ready` and then click on its name
- as the processor detail page opens, inspect the request to `GET /bridges/{bridgeId}/processors/{processorId}`, its response will report an empty object (`{}`) as value for the sensitive fields
- the sensitive values are displayed as a bunch of asterisks in the properties list
- now click on the edit button
- change an optional param like the transformation template
- notice that the sensitive fields in the form are empty, no value is displayed
- save the processor
- inspect the payload of the PUT request that saves the processor; the secret fields values are empty objects (`{}`), meaning the back-end will not overwrite the existing value provided when creating the processor
- finally, go back to the processors list and wait until the processor becomes `ready`
- click on the processor name to open its detail
- click on edit
- change one of the secret parameters by adding a new value
- save the processor
- inspect the payload of the PUT request that saves the processor; the edited secret parameters will have the new value, meaning the back-end will overwrite the previous one.