### PR TITLE
NO-JIRA: fix E2E test - REST was changed by MGDOBR-809

### DIFF
--- a/cypress/e2e/BasicTest.ts
+++ b/cypress/e2e/BasicTest.ts
@@ -42,6 +42,8 @@ describe("Basic Elements", () => {
       },
       body: {
         name: bridgeName,
+        cloud_provider: "aws",
+        region: "us-east-1",
       },
     };
     cy.request(options).then((response) => {


### PR DESCRIPTION
The [PR](https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox/pull/899) changed a creation of a bridge via REST API.

E2E tests start failing. I have added new parameters into REST request.

