### PR TITLE
[NO-JIRA]: Skeleton when missing endpoint

### DIFF
--- a/src/app/Instance/InstanceDetails/InstanceDetails.tsx
+++ b/src/app/Instance/InstanceDetails/InstanceDetails.tsx
@@ -11,6 +11,7 @@ import {
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
+  Skeleton,
   Stack,
   StackItem,
   Text,
@@ -108,16 +109,20 @@ export const InstanceDetails = ({
                   </Text>
                 </StackItem>
                 <StackItem>
-                  <ClipboardCopy
-                    data-ouia-component-id="instance-details-endpoint"
-                    isBlock
-                    isReadOnly
-                    hoverTip={t("common.copy")}
-                    clickTip={t("common.copied")}
-                    variant={ClipboardCopyVariant.inlineCompact}
-                  >
-                    {instance.endpoint}
-                  </ClipboardCopy>
+                  {instance.endpoint ? (
+                    <ClipboardCopy
+                      data-ouia-component-id="instance-details-endpoint"
+                      isBlock
+                      isReadOnly
+                      hoverTip={t("common.copy")}
+                      clickTip={t("common.copied")}
+                      variant={ClipboardCopyVariant.inlineCompact}
+                    >
+                      {instance.endpoint}
+                    </ClipboardCopy>
+                  ) : (
+                    <Skeleton fontSize="4xl" width="100%" />
+                  )}
                 </StackItem>
               </Stack>
             </DescriptionListDescription>


### PR DESCRIPTION
When no endpoint URL is available (instance creation is still in progress) a skeleton will be shown:
![image](https://user-images.githubusercontent.com/22591802/182149957-43d5de4a-0571-41b3-a7db-39bfea7aafca.png)
In that image the missing endpoint has been forced programmatically, but you can simulate this situation with the real API.