### PR TITLE
NO-JIRA: Disable react-router-dom singleton

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -129,32 +129,24 @@ module.exports = (env, argv) => {
         shared: {
           ...dependencies,
           react: {
-            eager: true,
             singleton: true,
             requiredVersion: dependencies["react"],
           },
           "react-dom": {
-            eager: true,
             singleton: true,
             requiredVersion: dependencies["react-dom"],
           },
           "react-router-dom": {
-            singleton: true,
-            eager: true,
+            singleton: false, // consoledot needs this to be off to be able to upgrade the router to v6. We don't need this to be a singleton, so let's keep this off
             requiredVersion: dependencies["react-router-dom"],
           },
           "react-i18next": {
-            eager: true,
             singleton: true,
             requiredVersion: dependencies["react-i18next"],
           },
           "@rhoas/app-services-ui-components": {
             singleton: true,
             requiredVersion: dependencies["@rhoas/app-services-ui-components"],
-          },
-          "@rhoas/app-services-ui-shared": {
-            singleton: true,
-            requiredVersion: dependencies["@rhoas/app-services-ui-shared"],
           },
           "@patternfly/quickstarts": {
             singleton: true,


### PR DESCRIPTION
> consoledot needs this to be off to be able to upgrade the router to v6. We don't need this to be a singleton, so let's keep this off. Also, remove all eager loading as we should never eagerly load any dependency ever; when eagerly loading, the dependency gets bundled with the bundle that will be loaded through module federation, forcing users to download them all over again