### PR TITLE
Remove 'monaco-editor' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "lodash.isequal": "4.5.0",
         "lodash.isequalwith": "4.4.0",
         "lodash.omit": "4.5.0",
-        "monaco-editor": "0.21.3",
         "monaco-editor-webpack-plugin": "2.1.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "lodash.isequal": "4.5.0",
     "lodash.isequalwith": "4.4.0",
     "lodash.omit": "4.5.0",
-    "monaco-editor": "0.21.3",
     "monaco-editor-webpack-plugin": "2.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",


### PR DESCRIPTION
'npx depcheck' marked 'monaco-editor' as unused dependnecy

My guess we use 'monaco-editor' just for processor template? It seems still up and running.
![Screenshot from 2022-08-26 15-52-52](https://user-images.githubusercontent.com/8044780/186920151-69a240ef-df03-4946-9883-627043b85488.png)
