### PR TITLE
MGDOBR-981: Action/Source configuration - browser saving/restoring form data

### DIFF
--- a/src/app/Instance/CreateInstance/CreateInstance.tsx
+++ b/src/app/Instance/CreateInstance/CreateInstance.tsx
@@ -366,7 +366,7 @@ const CreateInstance = (props: CreateInstanceProps): JSX.Element => {
         </Button>,
       ]}
     >
-      <Form id={FORM_ID} onSubmit={onSubmit}>
+      <Form id={FORM_ID} onSubmit={onSubmit} autoComplete="off">
         {(nameError || genericError || hasParametersError) && (
           <FormAlert>
             <Alert

--- a/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
+++ b/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
@@ -80,7 +80,6 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
         name,
         label,
         type: "password",
-        autocomplete: "new-password",
       };
     }
     return {

--- a/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
+++ b/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
@@ -80,6 +80,7 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
         name,
         label,
         type: "password",
+        autocomplete: "new-password",
       };
     }
     return {

--- a/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
+++ b/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
@@ -272,7 +272,7 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
                   grow={{ default: "grow" }}
                   className={"processor-edit__content-wrap"}
                 >
-                  <Form className={"processor-edit__form"}>
+                  <Form className={"processor-edit__form"} autoComplete="off">
                     <FormSection
                       title={t("processor.generalInformation")}
                       titleElement="h2"


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-981

Unfortunately there's no standard way to prevent browsers from asking to store credentials. 
This PR is focusing only on the `autocomplete` feature, to at least prevent form values from being auto-filled.

Steps to test it (on Chrome):
- Create a processor with an action/source with a password field
- Store the credentials
- Create another processor and check that the saved credentials are not auto-filled.