### PR TITLE
MGDOBR-970: E2E - manual execution of GHA is failing in the checkout …

### DIFF
--- a/.github/workflows/quality-checks-e2e.yml
+++ b/.github/workflows/quality-checks-e2e.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == '5733d9e2be6485d52ffa08870cabdee0/sandbox-ui'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.2
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Check labels


### PR DESCRIPTION
…action
https://issues.redhat.com/browse/MGDOBR-970

[This link](https://github.com/actions/checkout/issues/417#issuecomment-1052215302) suggests to update the version of checkout@action in `Smart Events UI :: Dev :: Quality Checks`.

I need to merge this PR to see the particular changes in GHA.