### PR TITLE
NO-JIRA: Prevent updates on react-monaco-editor

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
     {
       "matchPackagePatterns": ["^@?xstate"],
       "groupName": "xstate"
+    },
+    {
+      "matchPackageNames": ["react-monaco-editor"],
+      "allowedVersions": "<=0.41.2"
     }
   ]
 }


### PR DESCRIPTION
Updates to `react-monaco-editor` are causing issues because `@patternfly/react-code-editor` requires a specific version of it (`^0.41.2`) as peer dependecy.

```
Found file in cache: /tmp/containerbase/7576b42decc67f70b61585f41c5074bea75c260886346e567578ea0e0dc2d571/node-v16.17.0-linux-x64.tar.xz
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: smartevents-ui@0.0.1
npm ERR! Found: react-monaco-editor@0.50.1
npm ERR! node_modules/react-monaco-editor
npm ERR!   react-monaco-editor@"0.50.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react-monaco-editor@"^0.41.2" from @patternfly/react-code-editor@4.72.8
npm ERR! node_modules/@patternfly/react-code-editor
npm ERR!   @patternfly/react-code-editor@"4.72.8" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /tmp/renovate-cache/others/npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /tmp/renovate-cache/others/npm/_logs/2022-09-01T07_36_32_568Z-debug-0.log
```


I see the `0.41.2` version was released [2 years ago](https://www.npmjs.com/package/react-monaco-editor/v/0.41.2). So I presume the PF team is not updating it often.

I think a good option is just to disable updates on `react-monaco-editor` for now. 

We can manually change this when there will be changes on `@patternfly/react-code-editor` peer deps requirements.