### PR TITLE
MGDOBR-1059: Optional secrets value displayed as masked value even when the value was not set

### DIFF
--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
@@ -17,7 +17,7 @@ import {
   ERROR_HANDLING_METHODS,
   getErrorHandlingMethodByType,
 } from "../../../types/ErrorHandlingMethods";
-import ProcessorDetailConfigParameters from "@app/Processor/ProcessorDetail/ProcessorDetailConfigParameters";
+import ProcessorConfigParameters from "@app/Processor/ProcessorConfigParameters/ProcessorConfigParameters";
 import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useGetSchemaApi } from "../../../hooks/useSchemasApi/useGetSchemaApi";
@@ -129,7 +129,7 @@ export const ErrorHandlingTabContent = ({
               schema &&
               !schemaLoading &&
               !schemaError && (
-                <ProcessorDetailConfigParameters
+                <ProcessorConfigParameters
                   schema={schema}
                   parameters={errorHandlingParameters}
                 />

--- a/src/app/Processor/ProcessorConfigParameters/ProcessorConfigParameters.test.tsx
+++ b/src/app/Processor/ProcessorConfigParameters/ProcessorConfigParameters.test.tsx
@@ -1,0 +1,157 @@
+import { customRender, waitForI18n } from "@utils/testUtils";
+import React from "react";
+import ProcessorConfigParameters, {
+  maskedValue,
+} from "@app/Processor/ProcessorConfigParameters/ProcessorConfigParameters";
+import { JSONSchema7 } from "json-schema";
+import { fireEvent, RenderResult, waitFor } from "@testing-library/react";
+
+describe("ProcessorConfigParameters", () => {
+  it("should display properties and their values", async () => {
+    const comp = customRender(
+      <ProcessorConfigParameters
+        schema={testSchema as JSONSchema7}
+        parameters={{
+          user: "testUser",
+          password: {},
+          flag1: true,
+          flag2: false,
+          numeric: 3.14,
+          integer: 10,
+          data_shape: { produces: { format: "application/json" } },
+        }}
+      />
+    );
+    await waitForI18n(comp);
+
+    // string value
+    testProperty(comp, "user", "Username", "testUser");
+    // masked value
+    testProperty(comp, "password", "Password", maskedValue);
+    // boolean value set to true
+    testProperty(comp, "flag1", "Flag 1", "Yes");
+    // boolean value set to false
+    testProperty(comp, "flag2", "Flag 2", "No");
+    // numeric value
+    testProperty(comp, "numeric", "Number", "3.14");
+    // integer value
+    testProperty(comp, "integer", "Integer number", "10");
+    // data shape specific value
+    testProperty(comp, "data_shape", "data shape", "application/json");
+
+    // description tooltip
+    expect(
+      comp.queryByText(testSchema.properties.user.description)
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(comp.getByText("Username"));
+
+    await waitFor(() => {
+      expect(
+        comp.queryByText(testSchema.properties.user.description)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should display a message for properties not configured", async () => {
+    const comp = customRender(
+      <ProcessorConfigParameters
+        schema={testSchema as JSONSchema7}
+        parameters={{
+          user: "testUser",
+          data_shape: { produces: { format: "application/json" } },
+        }}
+      />
+    );
+    await waitForI18n(comp);
+
+    testProperty(comp, "user", "Username", "testUser");
+    testProperty(comp, "password", "Password", propertyNotConfigured);
+    testProperty(comp, "flag1", "Flag 1", propertyNotConfigured);
+    testProperty(comp, "flag2", "Flag 2", propertyNotConfigured);
+    testProperty(comp, "numeric", "Number", propertyNotConfigured);
+    testProperty(comp, "integer", "Integer number", propertyNotConfigured);
+    testProperty(comp, "data_shape", "data shape", "application/json");
+  });
+});
+
+const testProperty = (
+  comp: RenderResult,
+  key: string,
+  title: string,
+  value: string
+): void => {
+  expect(comp.getByTestId(key)).toHaveTextContent(title);
+  expect(comp.getByTestId(`${key}-value`)).toHaveTextContent(value);
+};
+
+const propertyNotConfigured = "Property not configured";
+
+const testSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["user"],
+  properties: {
+    user: {
+      title: "Username",
+      type: "string",
+      description: "The username you want to use.",
+    },
+    password: {
+      title: "Password",
+      "x-group": "credentials",
+      oneOf: [
+        {
+          title: "Password",
+          type: "string",
+          format: "password",
+        },
+        {
+          type: "object",
+          properties: {},
+        },
+      ],
+    },
+    flag1: {
+      title: "Flag 1",
+      type: "boolean",
+    },
+    flag2: {
+      title: "Flag 2",
+      type: "boolean",
+    },
+    numeric: {
+      title: "Number",
+      type: "number",
+    },
+    integer: {
+      title: "Integer number",
+      type: "integer",
+    },
+    data_shape: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        produces: {
+          $ref: "#/$defs/data_shape/produces",
+        },
+      },
+    },
+  },
+  $defs: {
+    data_shape: {
+      produces: {
+        type: "object",
+        additionalProperties: false,
+        required: ["format"],
+        properties: {
+          format: {
+            type: "string",
+            default: "application/json",
+            enum: ["application/json"],
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/app/Processor/ProcessorConfigParameters/ProcessorConfigParameters.tsx
+++ b/src/app/Processor/ProcessorConfigParameters/ProcessorConfigParameters.tsx
@@ -18,7 +18,7 @@ interface ProcessorDetailConfigParametersProps {
   parameters: { [key: string]: unknown };
 }
 
-const ProcessorDetailConfigParameters = (
+const ProcessorConfigParameters = (
   props: ProcessorDetailConfigParametersProps
 ): JSX.Element => {
   const { schema, parameters } = props;
@@ -30,11 +30,6 @@ const ProcessorDetailConfigParameters = (
         {schema.properties &&
           Object.entries(schema.properties)
             .filter(([key, value]) => {
-              // Processors property shouldn't be here.
-              // To be removed after https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox/pull/834
-              if (key === "processors") {
-                return false;
-              }
               // Keeping objects and arrays only if they are a data_shape
               if (
                 isJSONSchema(value) &&
@@ -70,7 +65,7 @@ const ProcessorDetailConfigParameters = (
   );
 };
 
-export default ProcessorDetailConfigParameters;
+export default ProcessorConfigParameters;
 
 const displayFieldName = (
   key: string,
@@ -84,14 +79,21 @@ const displayFieldName = (
     return (
       <DescriptionListTermHelpText>
         <Popover bodyContent={description}>
-          <DescriptionListTermHelpTextButton className={cssClass}>
+          <DescriptionListTermHelpTextButton
+            className={cssClass}
+            data-testid={key}
+          >
             {name}
           </DescriptionListTermHelpTextButton>
         </Popover>
       </DescriptionListTermHelpText>
     );
   }
-  return <DescriptionListTerm className={cssClass}>{name}</DescriptionListTerm>;
+  return (
+    <DescriptionListTerm className={cssClass} data-testid={key}>
+      {name}
+    </DescriptionListTerm>
+  );
 };
 
 const displayFieldValue = (
@@ -106,6 +108,7 @@ const displayFieldValue = (
     const noPropertySet = (): JSX.Element => (
       <DescriptionListDescription
         className={"processor-detail__property--not-set"}
+        data-testid={`${propertyKey}-value`}
       >
         {t("processor.propertyNotConfigured")}
       </DescriptionListDescription>
@@ -118,7 +121,7 @@ const displayFieldValue = (
         }
         if (value) {
           return (
-            <DescriptionListDescription>
+            <DescriptionListDescription data-testid={`${propertyKey}-value`}>
               {JSON.stringify(value)}
             </DescriptionListDescription>
           );
@@ -127,7 +130,7 @@ const displayFieldValue = (
       case "boolean":
         if (value !== undefined) {
           return (
-            <DescriptionListDescription>
+            <DescriptionListDescription data-testid={`${propertyKey}-value`}>
               {value ? t("common.yes") : t("common.no")}
             </DescriptionListDescription>
           );
@@ -136,7 +139,7 @@ const displayFieldValue = (
       case "string":
         if (value !== undefined) {
           return (
-            <DescriptionListDescription>
+            <DescriptionListDescription data-testid={`${propertyKey}-value`}>
               {value as string}
             </DescriptionListDescription>
           );
@@ -146,7 +149,7 @@ const displayFieldValue = (
       case "integer":
         if (value !== undefined) {
           return (
-            <DescriptionListDescription>
+            <DescriptionListDescription data-testid={`${propertyKey}-value`}>
               {value as number}
             </DescriptionListDescription>
           );
@@ -157,9 +160,9 @@ const displayFieldValue = (
           const passwordField = oneOf.filter(
             (item) => typeof item !== "boolean" && item?.format === "password"
           );
-          if (passwordField) {
+          if (passwordField && value) {
             return (
-              <DescriptionListDescription>
+              <DescriptionListDescription data-testid={`${propertyKey}-value`}>
                 {maskedValue}
               </DescriptionListDescription>
             );
@@ -176,7 +179,7 @@ export const DataShape = ({ data }: { data: DataShapeValue }): JSX.Element => {
     <>
       {Object.keys(data).map((key) => {
         return (
-          <DescriptionListDescription key={key}>
+          <DescriptionListDescription key={key} data-testid="data_shape-value">
             {data?.[key]?.format}
           </DescriptionListDescription>
         );

--- a/src/app/Processor/ProcessorDetail/ProcessorDetail.test.tsx
+++ b/src/app/Processor/ProcessorDetail/ProcessorDetail.test.tsx
@@ -10,7 +10,7 @@ import {
   ManagedResourceStatus,
   ProcessorType,
 } from "@rhoas/smart-events-management-sdk";
-import { maskedValue } from "@app/Processor/ProcessorDetail/ProcessorDetailConfigParameters";
+import { maskedValue } from "@app/Processor/ProcessorConfigParameters/ProcessorConfigParameters";
 
 describe("ProcessorDetail component", () => {
   it("should display sink processor information", async () => {

--- a/src/app/Processor/ProcessorDetail/ProcessorDetail.tsx
+++ b/src/app/Processor/ProcessorDetail/ProcessorDetail.tsx
@@ -33,7 +33,7 @@ import {
   ProcessorType,
 } from "@rhoas/smart-events-management-sdk";
 import { GetSchema } from "../../../hooks/useSchemasApi/useGetSchemaApi";
-import ProcessorDetailConfigParameters from "@app/Processor/ProcessorDetail/ProcessorDetailConfigParameters";
+import ProcessorConfigParameters from "@app/Processor/ProcessorConfigParameters/ProcessorConfigParameters";
 import axios from "axios";
 import {
   getErrorCode,
@@ -140,7 +140,7 @@ const ProcessorDetail = (props: ProcessorDetailProps): JSX.Element => {
                 </DescriptionListGroup>
                 {schema && !schemaError && !schemaLoading && (
                   <>
-                    <ProcessorDetailConfigParameters
+                    <ProcessorConfigParameters
                       schema={schema}
                       parameters={processorConfig as { [key: string]: unknown }}
                     />
@@ -274,7 +274,7 @@ const ProcessorDetail = (props: ProcessorDetailProps): JSX.Element => {
                   </DescriptionListGroup>
                   {schema && !schemaLoading && (
                     <>
-                      <ProcessorDetailConfigParameters
+                      <ProcessorConfigParameters
                         schema={schema}
                         parameters={
                           processorConfig as { [key: string]: unknown }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-1059

Steps to test:
- Create a bridge with webhook error handler **without** providing a user/password combination
- Wait for the bridge to get ready
- Open the bridge, click on the `Error handling` link
- The password field value is displayed as `Property not configured` (it was a masked value before)

Same thing can be tested on a sink processor with webhook action. It's the same component used there too. 