### PR TITLE
MGDOBR-1108: Red Hat font not loading properly

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -51,39 +51,27 @@ module.exports = (env, argv) => {
         },
         {
           test: /\.(ttf|eot|woff|woff2)$/,
-          use: {
-            loader: "file-loader",
-            options: {
-              limit: 5000,
-              name: isProduction ? "[contenthash:8].[ext]" : "[name].[ext]",
-            },
+          type: "asset/resource",
+          generator: {
+            filename: isProduction ? "[contenthash:8].[ext]" : "[name].[ext]",
           },
         },
         {
           test: /\.(svg|jpg|jpeg|png|gif)$/i,
-          use: [
-            {
-              loader: "url-loader",
-              options: {
-                limit: 5000,
-                name: isProduction ? "[contenthash:8].[ext]" : "[name].[ext]",
-              },
-            },
-          ],
+          type: "asset",
+          generator: {
+            filename: isProduction ? "[contenthash:8].[ext]" : "[name].[ext]",
+          },
         },
         {
           test: /\.(json)$/i,
           include: path.resolve(__dirname, "src/locales"),
-          use: [
-            {
-              loader: "url-loader",
-              options: {
-                limit: 5000,
-                outputPath: "locales",
-                name: isProduction ? "[contenthash:8].[ext]" : "[name].[ext]",
-              },
-            },
-          ],
+          type: "asset",
+          generator: {
+            filename: isProduction
+              ? "locales/[contenthash:8].[ext]"
+              : "locales/[name].[ext]",
+          },
         },
       ],
     },


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-1108

Issue was caused by the update to `css-loader@6.7.1` introduced with #164.

As reported by `css-loader` [release notes](https://github.com/webpack-contrib/css-loader/releases/tag/v6.0.0), some changes to the webpack configuration for assets fix the problem.

To test that the Red Hat font is properly used, inspect a text node with chrome developer tools and look for the computed tab.

___

Before

![before](https://user-images.githubusercontent.com/1220606/192789435-53986f0d-f308-4365-befb-2781b8e0b80c.png)  

After

![after](https://user-images.githubusercontent.com/1220606/192789466-5950fc87-874b-43c1-a545-140899d66d2c.png) 