### PR TITLE
MGDOBR-930: Warnings about invalid props inside forms generated with json schema

### DIFF
--- a/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
+++ b/src/app/Processor/ProcessorEdit/ConfigurationForm/CustomJsonSchemaBridge.tsx
@@ -5,6 +5,16 @@ import { TFunction } from "@rhoas/app-services-ui-components";
 import JSONSchemaBridge from "uniforms-bridge-json-schema";
 import { Popover } from "@patternfly/react-core";
 import { HelpIcon } from "@patternfly/react-icons";
+import { filterDOMProps } from "uniforms";
+
+declare module "uniforms" {
+  interface FilterDOMProps {
+    $comment: never;
+    isSecret: never;
+  }
+}
+
+filterDOMProps.register("$comment", "isSecret");
 
 /**
  * Returns an example string formatted (not localized) for the form or undefined if the field has no example text


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-930

Filtering `$comment` and `isSecret` props causing react console warnings. They should not be forwarded down to uniforms fields. 
