### PR TITLE
NO-JIRA: remove unused @types/node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "@types/lodash.isequal": "4.5.6",
         "@types/lodash.isequalwith": "4.4.7",
         "@types/lodash.omit": "4.5.7",
-        "@types/node": "17.0.25",
         "@types/react": "17.0.50",
         "@types/react-dom": "17.0.17",
         "@types/react-router-dom": "5.3.3",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/lodash.isequal": "4.5.6",
     "@types/lodash.isequalwith": "4.4.7",
     "@types/lodash.omit": "4.5.7",
-    "@types/node": "17.0.25",
     "@types/react": "17.0.50",
     "@types/react-dom": "17.0.17",
     "@types/react-router-dom": "5.3.3",


### PR DESCRIPTION
It was introduced (by me actually) with #24 but it's not required for msw.