### PR TITLE
MGDOBR-1094: Enable the edit button in case of Processor is in Failed state

### DIFF
--- a/src/app/Processor/ProcessorDetailPage/ProcessorDetailPage.tsx
+++ b/src/app/Processor/ProcessorDetailPage/ProcessorDetailPage.tsx
@@ -28,14 +28,13 @@ import ProcessorDetailSkeleton from "@app/Processor/ProcessorDetail/ProcessorDet
 import ProcessorEdit from "@app/Processor/ProcessorEdit/ProcessorEdit";
 import { useUpdateProcessorApi } from "../../../hooks/useProcessorsApi/useUpdateProcessorApi";
 import {
-  ManagedResourceStatus,
   ProcessorRequest,
   ProcessorResponse,
 } from "@rhoas/smart-events-management-sdk";
 import axios from "axios";
 import { ErrorWithDetail } from "../../../types/Error";
 import DeleteProcessor from "@app/Processor/DeleteProcessor/DeleteProcessor";
-import { canDeleteResource } from "@utils/resourceUtils";
+import { canDeleteResource, canEditResource } from "@utils/resourceUtils";
 import { useGetSchemasApi } from "../../../hooks/useSchemasApi/useGetSchemasApi";
 import { useGetSchemaApi } from "../../../hooks/useSchemasApi/useGetSchemaApi";
 import {
@@ -362,8 +361,7 @@ const ProcessorDetailPage = (): JSX.Element => {
                     <SplitItem>
                       <Button
                         isAriaDisabled={
-                          currentProcessor.status !==
-                            ManagedResourceStatus.Ready ||
+                          !canEditResource(currentProcessor.status) ||
                           schemaError !== undefined
                         }
                         ouiaId="edit"

--- a/src/utils/resourceUtils.tsx
+++ b/src/utils/resourceUtils.tsx
@@ -1,12 +1,23 @@
 import { ManagedResourceStatus } from "@rhoas/smart-events-management-sdk";
 
-const canDeleteResource = (resourceStatus: ManagedResourceStatus): boolean => {
-  /** It's only possible to delete a resource if it's in the "ready" or "failed" status
-   * see https://issues.redhat.com/browse/MGDOBR-398 for more details */
+const isResourceActionable = (
+  resourceStatus: ManagedResourceStatus
+): boolean => {
+  /** It's only possible to edit a resource if it's in the "ready" or "failed" status */
   return (
     resourceStatus === ManagedResourceStatus.Ready ||
     resourceStatus === ManagedResourceStatus.Failed
   );
 };
 
-export { canDeleteResource };
+const canDeleteResource = (resourceStatus: ManagedResourceStatus): boolean => {
+  /** It's only possible to delete a resource if it's in the "ready" or "failed" status
+   * see https://issues.redhat.com/browse/MGDOBR-398 for more details */
+  return isResourceActionable(resourceStatus);
+};
+
+const canEditResource = (resourceStatus: ManagedResourceStatus): boolean => {
+  /** It's only possible to edit a resource if it's in the "ready" or "failed" status */
+  return isResourceActionable(resourceStatus);
+};
+export { canDeleteResource, canEditResource };


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-1094

Steps to test it (on chrome):

- Create the Processor with Incorrect parameters to enter into Failed state.
- Check for the Edit button to update the parameters to make it to Ready state.