### PR TITLE
[No-Jira] Accept missing instance progress poppup as valid state of t…

### DIFF
--- a/cypress/integration/instance/InstanceCreation.ts
+++ b/cypress/integration/instance/InstanceCreation.ts
@@ -69,12 +69,13 @@ describe("the 'Create a SE instance' Modal", () => {
           console.error("runnable", runnable);
 
           if (
+            isEnvironmentType(EnvType.Dev) &&
             e.name === "AssertionError" &&
             e.message.includes("of 3 steps completed")
           ) {
-            return false;
+            return true; //does not matter if true or false
           }
-          return true;
+          throw e;
         });
 
         progressStepsStatuses(SEInstanceStatus.ACCEPTED);

--- a/cypress/integration/instance/InstanceCreation.ts
+++ b/cypress/integration/instance/InstanceCreation.ts
@@ -59,6 +59,24 @@ describe("the 'Create a SE instance' Modal", () => {
           "have.text",
           "0 of 3 steps completed"
         );
+
+        // Prepare cypress for 'non deterministic' updates in 'Status' popover
+        // The 'deterministic' updates would be: (0 of 3, 1 of 3, 2 of 3 and Done)
+        // However in reality it may happen: (0 of 3, 1 of 3 and Done) or (0 of 3, 2 of 3 and Done) or ...
+        // see https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__errors/cypress/e2e/test-fails.cy.js
+        cy.on("fail", (e, runnable) => {
+          console.error("error", e);
+          console.error("runnable", runnable);
+
+          if (
+            e.name === "AssertionError" &&
+            e.message.includes("of 3 steps completed")
+          ) {
+            return false;
+          }
+          return true;
+        });
+
         progressStepsStatuses(SEInstanceStatus.ACCEPTED);
         cy.ouiaId("steps-count", "QE/StackItem", { timeout: 120000 }).should(
           "have.text",


### PR DESCRIPTION
…he application

There are some non deterministic situations in our application, when some popover dialog may or may not be present on the page. Examples of such situations are:
1.) Consent with cookies popover in the very start of the application/test 2.) Smart Event Instance status progress popover

The 1.) is for some user displayed, for some it is not. We Are not sure why this happens. The guess for a root case is a country of the machine, where the test is running. Needs more investigations/test results tracking. The 2.) displays progress as three steps. However the time combination of time needed for the operation on backend with polling interval from UI causes, soemtimes the progress update is not 'smooth' and popover disappears faster than expected in the test.

*This PR tries to stabilize 2.)*

The error handling was addopted according to th ecyprtess example:
- https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__errors/cypress/e2e/test-fails.cy.js

![Screenshot from 2022-10-14 10-19-00](https://user-images.githubusercontent.com/8044780/195823184-f67b091b-1459-40fb-a7ed-48541cefa526.png)