### PR TITLE
MGDOBR-1129: Refactor the Instance Page layout for adherence with UX prototype

### DIFF
--- a/cypress/integration/ActionTest.ts
+++ b/cypress/integration/ActionTest.ts
@@ -44,7 +44,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
 
       it("The default state of the configuration", () => {
         //mention only for purpose to make actions visible
-        cy.get(".processor-edit__content-wrap").scrollTo("bottom");
+        cy.get("#processor-form-container").scrollTo("bottom");
 
         cy.ouiaId("missing-actions", "PF4/TextInput")
           .should("be.visible")
@@ -105,7 +105,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
 
         it("Check parameters", () => {
           //mention only for purpose to make parameters visible
-          cy.get(".processor-edit__content-wrap").scrollTo("bottom");
+          cy.get("#processor-form-container").scrollTo("bottom");
 
           cy.ouiaId("configuration").within(() => {
             cy.ouiaType("config-parameter").should("have.length", 5);
@@ -130,7 +130,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
         it("Save the required parameter without any value", () => {
           cy.ouiaId("submit").click();
           //mention only for purpose to make parameters visible
-          cy.get(".processor-edit__content-wrap").scrollTo("bottom");
+          cy.get("#processor-form-container").scrollTo("bottom");
 
           cy.ouiaId("configuration")
             .should("be.visible")

--- a/src/app/Instance/ErrorHandling/ErrorHandlingDetail.test.tsx
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingDetail.test.tsx
@@ -14,6 +14,8 @@ describe("ErrorHandlingDetail component", () => {
       <ErrorHandlingDetail
         isBridgeLoading={false}
         isSchemaLoading={false}
+        onEdit={jest.fn}
+        isEditDisabled={false}
         {...props}
       />
     );

--- a/src/app/Instance/ErrorHandling/ErrorHandlingDetail.tsx
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingDetail.tsx
@@ -5,7 +5,6 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  PageSection,
   PageSectionVariants,
   Skeleton,
   Split,
@@ -23,6 +22,7 @@ import {
   getErrorHandlingMethodByType,
 } from "../../../types/ErrorHandlingMethods";
 import ConfigParameters from "@app/components/ConfigParameters/ConfigParameters";
+import ErrorHandlingPageSection from "@app/Instance/ErrorHandling/ErrorHandlingPageSection";
 
 export interface ErrorHandlingDetailProps {
   errorHandlingType?: string;
@@ -78,11 +78,7 @@ export const ErrorHandlingDetail = ({
   }, [errorHandlingParameters]);
 
   return (
-    <PageSection
-      variant={PageSectionVariants.light}
-      isFilled
-      className={"pf-u-h-100"}
-    >
+    <ErrorHandlingPageSection variant={PageSectionVariants.light}>
       <Stack hasGutter>
         <StackItem>
           <Split hasGutter>
@@ -146,6 +142,6 @@ export const ErrorHandlingDetail = ({
           </DescriptionList>
         </StackItem>
       </Stack>
-    </PageSection>
+    </ErrorHandlingPageSection>
   );
 };

--- a/src/app/Instance/ErrorHandling/ErrorHandlingDetail.tsx
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingDetail.tsx
@@ -1,10 +1,18 @@
 import {
   Alert,
+  Button,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
   Skeleton,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
+  TextVariants,
 } from "@patternfly/react-core";
 import React, { useMemo } from "react";
 import { useTranslation } from "@rhoas/app-services-ui-components";
@@ -21,6 +29,8 @@ export interface ErrorHandlingDetailProps {
   schema?: object;
   isSchemaLoading: boolean;
   apiError?: string;
+  onEdit: () => void;
+  isEditDisabled: boolean;
 }
 
 export const ErrorHandlingDetail = ({
@@ -30,6 +40,8 @@ export const ErrorHandlingDetail = ({
   schema,
   isSchemaLoading,
   apiError,
+  onEdit,
+  isEditDisabled,
 }: ErrorHandlingDetailProps): JSX.Element => {
   const { t } = useTranslation(["openbridgeTempDictionary"]);
 
@@ -64,36 +76,65 @@ export const ErrorHandlingDetail = ({
   }, [errorHandlingParameters]);
 
   return (
-    <DescriptionList>
-      <DescriptionListGroup
-        data-ouia-component-type="ProcessorConfig/FormGroup"
-        data-ouia-component-id="error_handling_method"
-        key="error-handling-method"
-      >
-        <DescriptionListTerm data-testid="error_handling_method">
-          {t("common.errorHandlingMethod")}
-        </DescriptionListTerm>
-        <DescriptionListDescription data-testid="error_handling_method-value">
-          {errorHandlingMethodLabel}
-        </DescriptionListDescription>
-      </DescriptionListGroup>
-      {errorHandlingParameters && schema && !isSchemaLoading && !apiError && (
-        <ConfigParameters
-          schema={schema}
-          parameters={errorHandlingParameters as { [key: string]: unknown }}
-        />
-      )}
-      {isSchemaLoading && errorHandlingParametersSkeleton}
-      {apiError && (
-        <Alert
-          className="instance-page__tabs-error-handling__alert"
-          ouiaId="error-schema"
-          variant="danger"
-          title={apiError}
-          aria-live="polite"
-          isInline
-        />
-      )}
-    </DescriptionList>
+    <Stack hasGutter>
+      <StackItem>
+        <Split hasGutter>
+          <SplitItem isFilled>
+            <TextContent>
+              <Text component={TextVariants.h3} ouiaId="error-handling-section">
+                {t("common.errorHandlingMethod")}
+              </Text>
+            </TextContent>
+          </SplitItem>
+          <SplitItem>
+            <Button
+              isAriaDisabled={isEditDisabled}
+              ouiaId="edit"
+              onClick={onEdit}
+            >
+              {t("common.edit")}
+            </Button>
+          </SplitItem>
+        </Split>
+      </StackItem>
+      <StackItem>
+        <DescriptionList>
+          <DescriptionListGroup
+            data-ouia-component-type="ProcessorConfig/FormGroup"
+            data-ouia-component-id="error_handling_method"
+            key="error-handling-method"
+          >
+            <DescriptionListTerm data-testid="error_handling_method">
+              {t("common.errorHandlingMethod")}
+            </DescriptionListTerm>
+            <DescriptionListDescription data-testid="error_handling_method-value">
+              {errorHandlingMethodLabel}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          {errorHandlingParameters &&
+            schema &&
+            !isSchemaLoading &&
+            !apiError && (
+              <ConfigParameters
+                schema={schema}
+                parameters={
+                  errorHandlingParameters as { [key: string]: unknown }
+                }
+              />
+            )}
+          {isSchemaLoading && errorHandlingParametersSkeleton}
+          {apiError && (
+            <Alert
+              className="instance-page__tabs-error-handling__alert"
+              ouiaId="error-schema"
+              variant="danger"
+              title={apiError}
+              aria-live="polite"
+              isInline
+            />
+          )}
+        </DescriptionList>
+      </StackItem>
+    </Stack>
   );
 };

--- a/src/app/Instance/ErrorHandling/ErrorHandlingDetail.tsx
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingDetail.tsx
@@ -5,6 +5,8 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  PageSection,
+  PageSectionVariants,
   Skeleton,
   Split,
   SplitItem,
@@ -76,65 +78,74 @@ export const ErrorHandlingDetail = ({
   }, [errorHandlingParameters]);
 
   return (
-    <Stack hasGutter>
-      <StackItem>
-        <Split hasGutter>
-          <SplitItem isFilled>
-            <TextContent>
-              <Text component={TextVariants.h3} ouiaId="error-handling-section">
-                {t("common.errorHandlingMethod")}
-              </Text>
-            </TextContent>
-          </SplitItem>
-          <SplitItem>
-            <Button
-              isAriaDisabled={isEditDisabled}
-              ouiaId="edit"
-              onClick={onEdit}
+    <PageSection
+      variant={PageSectionVariants.light}
+      isFilled
+      className={"pf-u-h-100"}
+    >
+      <Stack hasGutter>
+        <StackItem>
+          <Split hasGutter>
+            <SplitItem isFilled>
+              <TextContent>
+                <Text
+                  component={TextVariants.h3}
+                  ouiaId="error-handling-section"
+                >
+                  {t("common.errorHandlingMethod")}
+                </Text>
+              </TextContent>
+            </SplitItem>
+            <SplitItem>
+              <Button
+                isAriaDisabled={isEditDisabled}
+                ouiaId="edit"
+                onClick={onEdit}
+              >
+                {t("common.edit")}
+              </Button>
+            </SplitItem>
+          </Split>
+        </StackItem>
+        <StackItem>
+          <DescriptionList>
+            <DescriptionListGroup
+              data-ouia-component-type="ProcessorConfig/FormGroup"
+              data-ouia-component-id="error_handling_method"
+              key="error-handling-method"
             >
-              {t("common.edit")}
-            </Button>
-          </SplitItem>
-        </Split>
-      </StackItem>
-      <StackItem>
-        <DescriptionList>
-          <DescriptionListGroup
-            data-ouia-component-type="ProcessorConfig/FormGroup"
-            data-ouia-component-id="error_handling_method"
-            key="error-handling-method"
-          >
-            <DescriptionListTerm data-testid="error_handling_method">
-              {t("common.errorHandlingMethod")}
-            </DescriptionListTerm>
-            <DescriptionListDescription data-testid="error_handling_method-value">
-              {errorHandlingMethodLabel}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          {errorHandlingParameters &&
-            schema &&
-            !isSchemaLoading &&
-            !apiError && (
-              <ConfigParameters
-                schema={schema}
-                parameters={
-                  errorHandlingParameters as { [key: string]: unknown }
-                }
+              <DescriptionListTerm data-testid="error_handling_method">
+                {t("common.errorHandlingMethod")}
+              </DescriptionListTerm>
+              <DescriptionListDescription data-testid="error_handling_method-value">
+                {errorHandlingMethodLabel}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {errorHandlingParameters &&
+              schema &&
+              !isSchemaLoading &&
+              !apiError && (
+                <ConfigParameters
+                  schema={schema}
+                  parameters={
+                    errorHandlingParameters as { [key: string]: unknown }
+                  }
+                />
+              )}
+            {isSchemaLoading && errorHandlingParametersSkeleton}
+            {apiError && (
+              <Alert
+                className="instance-page__tabs-error-handling__alert"
+                ouiaId="error-schema"
+                variant="danger"
+                title={apiError}
+                aria-live="polite"
+                isInline
               />
             )}
-          {isSchemaLoading && errorHandlingParametersSkeleton}
-          {apiError && (
-            <Alert
-              className="instance-page__tabs-error-handling__alert"
-              ouiaId="error-schema"
-              variant="danger"
-              title={apiError}
-              aria-live="polite"
-              isInline
-            />
-          )}
-        </DescriptionList>
-      </StackItem>
-    </Stack>
+          </DescriptionList>
+        </StackItem>
+      </Stack>
+    </PageSection>
   );
 };

--- a/src/app/Instance/ErrorHandling/ErrorHandlingEdit.css
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingEdit.css
@@ -1,5 +1,4 @@
 .error-handling-edit-form {
-  --eh-edit--spacing: var(--pf-global--spacer--lg);
   max-width: 800px;
-  padding: var(--eh-edit--spacing);
+  padding: var(--pf-global--spacer--lg);
 }

--- a/src/app/Instance/ErrorHandling/ErrorHandlingEdit.css
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingEdit.css
@@ -1,3 +1,5 @@
 .error-handling-edit-form {
+  --eh-edit--spacing: var(--pf-global--spacer--lg);
   max-width: 800px;
+  padding: var(--eh-edit--spacing);
 }

--- a/src/app/Instance/ErrorHandling/ErrorHandlingEdit.tsx
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingEdit.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   ActionGroup,
   Alert,
@@ -6,6 +6,8 @@ import {
   Form,
   FormAlert,
   FormSection,
+  PageSection,
+  PageSectionVariants,
   Text,
   TextContent,
   TextVariants,
@@ -53,14 +55,10 @@ export const ErrorHandlingEdit = ({
     []
   );
 
-  const onSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      onErrorHandlingSubmit(errorHandlingMethod, errorHandlingParameters);
-      setIsSubmitted(true);
-    },
-    [errorHandlingMethod, errorHandlingParameters, onErrorHandlingSubmit]
-  );
+  const onSubmit = useCallback(() => {
+    onErrorHandlingSubmit(errorHandlingMethod, errorHandlingParameters);
+    setIsSubmitted(true);
+  }, [errorHandlingMethod, errorHandlingParameters, onErrorHandlingSubmit]);
 
   useEffect(() => {
     if (isSubmitted) {
@@ -76,64 +74,71 @@ export const ErrorHandlingEdit = ({
   }, [isSubmitted]);
 
   return (
-    <StickyActionsLayout
-      actions={
-        <ActionGroup className="error-handling-edit__actions">
-          <Button
-            variant="primary"
-            ouiaId="submit"
-            type="submit"
-            isLoading={isLoading}
-            isDisabled={isLoading}
-          >
-            {t("common.save")}
-          </Button>
-          <Button
-            variant="link"
-            ouiaId="cancel"
-            onClick={onCancelEditing}
-            isDisabled={isLoading}
-          >
-            {t("common.cancel")}
-          </Button>
-        </ActionGroup>
-      }
+    <PageSection
+      variant={PageSectionVariants.light}
+      isFilled
+      padding={{ default: "noPadding" }}
+      className={"pf-u-h-100"}
     >
-      <Form
-        className="error-handling-edit-form"
-        autoComplete="off"
-        onSubmit={onSubmit}
+      <StickyActionsLayout
+        actions={
+          <ActionGroup className="error-handling-edit__actions">
+            <Button
+              variant="primary"
+              ouiaId="submit"
+              type="submit"
+              onClick={onSubmit}
+              isLoading={isLoading}
+              isDisabled={isLoading}
+            >
+              {t("common.save")}
+            </Button>
+            <Button
+              variant="link"
+              ouiaId="cancel"
+              onClick={onCancelEditing}
+              isDisabled={isLoading}
+            >
+              {t("common.cancel")}
+            </Button>
+          </ActionGroup>
+        }
       >
-        {apiError && (
-          <FormAlert>
-            <Alert
-              className="error-handling-edit__alert"
-              ouiaId="error-schema"
-              variant="danger"
-              title={apiError}
-              aria-live="polite"
-              isInline
+        <Form className="error-handling-edit-form" autoComplete="off">
+          {apiError && (
+            <FormAlert>
+              <Alert
+                className="error-handling-edit__alert"
+                ouiaId="error-schema"
+                variant="danger"
+                title={apiError}
+                aria-live="polite"
+                isInline
+              />
+            </FormAlert>
+          )}
+          <FormSection
+            title={
+              <TextContent>
+                <Text
+                  component={TextVariants.h3}
+                  ouiaId="error-handling-section"
+                >
+                  {t("common.errorHandlingMethod")}
+                </Text>
+              </TextContent>
+            }
+          >
+            <ErrorHandlingCreate
+              schemaId={errorHandlingMethod}
+              getSchema={getSchema}
+              registerValidation={registerValidateParameters}
+              onChange={onErrorHandlingParametersChange}
+              parameters={errorHandlingParameters}
             />
-          </FormAlert>
-        )}
-        <FormSection
-          title={
-            <TextContent>
-              <Text component={TextVariants.h3} ouiaId="error-handling-section">
-                {t("common.errorHandlingMethod")}
-              </Text>
-            </TextContent>
-          }
-        >
-          <ErrorHandlingCreate
-            schemaId={errorHandlingMethod}
-            getSchema={getSchema}
-            registerValidation={registerValidateParameters}
-            onChange={onErrorHandlingParametersChange}
-            parameters={errorHandlingParameters}
-          />
-        </FormSection>
-      </Form>
-    </StickyActionsLayout>
+          </FormSection>
+        </Form>
+      </StickyActionsLayout>
+    </PageSection>
   );
 };

--- a/src/app/Instance/ErrorHandling/ErrorHandlingEdit.tsx
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingEdit.tsx
@@ -6,7 +6,6 @@ import {
   Form,
   FormAlert,
   FormSection,
-  PageSection,
   PageSectionVariants,
   Text,
   TextContent,
@@ -16,6 +15,7 @@ import { useTranslation } from "@rhoas/app-services-ui-components";
 import ErrorHandlingCreate from "@app/Instance/ErrorHandling/ErrorHandlingCreate";
 import StickyActionsLayout from "@app/components/StickyActionsLayout/StickyActionsLayout";
 import "./ErrorHandlingEdit.css";
+import ErrorHandlingPageSection from "@app/Instance/ErrorHandling/ErrorHandlingPageSection";
 
 export interface ErrorHandlingEditProps {
   apiError?: string;
@@ -74,11 +74,9 @@ export const ErrorHandlingEdit = ({
   }, [isSubmitted]);
 
   return (
-    <PageSection
+    <ErrorHandlingPageSection
       variant={PageSectionVariants.light}
-      isFilled
       padding={{ default: "noPadding" }}
-      className={"pf-u-h-100"}
     >
       <StickyActionsLayout
         actions={
@@ -139,6 +137,6 @@ export const ErrorHandlingEdit = ({
           </FormSection>
         </Form>
       </StickyActionsLayout>
-    </PageSection>
+    </ErrorHandlingPageSection>
   );
 };

--- a/src/app/Instance/ErrorHandling/ErrorHandlingEdit.tsx
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingEdit.tsx
@@ -5,10 +5,15 @@ import {
   Button,
   Form,
   FormAlert,
-  PageSection,
+  FormSection,
+  Text,
+  TextContent,
+  TextVariants,
 } from "@patternfly/react-core";
 import { useTranslation } from "@rhoas/app-services-ui-components";
 import ErrorHandlingCreate from "@app/Instance/ErrorHandling/ErrorHandlingCreate";
+import StickyActionsLayout from "@app/components/StickyActionsLayout/StickyActionsLayout";
+import "./ErrorHandlingEdit.css";
 
 export interface ErrorHandlingEditProps {
   apiError?: string;
@@ -71,35 +76,8 @@ export const ErrorHandlingEdit = ({
   }, [isSubmitted]);
 
   return (
-    <Form
-      className="error-handling-edit-form"
-      autoComplete="off"
-      onSubmit={onSubmit}
-    >
-      {apiError && (
-        <FormAlert>
-          <Alert
-            className="error-handling-edit__alert"
-            ouiaId="error-schema"
-            variant="danger"
-            title={apiError}
-            aria-live="polite"
-            isInline
-          />
-        </FormAlert>
-      )}
-      <ErrorHandlingCreate
-        schemaId={errorHandlingMethod}
-        getSchema={getSchema}
-        registerValidation={registerValidateParameters}
-        onChange={onErrorHandlingParametersChange}
-        parameters={errorHandlingParameters}
-      />
-      <PageSection
-        stickyOnBreakpoint={{ default: "bottom" }}
-        padding={{ default: "noPadding" }}
-        style={{ boxShadow: "none" }}
-      >
+    <StickyActionsLayout
+      actions={
         <ActionGroup className="error-handling-edit__actions">
           <Button
             variant="primary"
@@ -119,7 +97,43 @@ export const ErrorHandlingEdit = ({
             {t("common.cancel")}
           </Button>
         </ActionGroup>
-      </PageSection>
-    </Form>
+      }
+    >
+      <Form
+        className="error-handling-edit-form"
+        autoComplete="off"
+        onSubmit={onSubmit}
+      >
+        {apiError && (
+          <FormAlert>
+            <Alert
+              className="error-handling-edit__alert"
+              ouiaId="error-schema"
+              variant="danger"
+              title={apiError}
+              aria-live="polite"
+              isInline
+            />
+          </FormAlert>
+        )}
+        <FormSection
+          title={
+            <TextContent>
+              <Text component={TextVariants.h3} ouiaId="error-handling-section">
+                {t("common.errorHandlingMethod")}
+              </Text>
+            </TextContent>
+          }
+        >
+          <ErrorHandlingCreate
+            schemaId={errorHandlingMethod}
+            getSchema={getSchema}
+            registerValidation={registerValidateParameters}
+            onChange={onErrorHandlingParametersChange}
+            parameters={errorHandlingParameters}
+          />
+        </FormSection>
+      </Form>
+    </StickyActionsLayout>
   );
 };

--- a/src/app/Instance/ErrorHandling/ErrorHandlingPageSection.tsx
+++ b/src/app/Instance/ErrorHandling/ErrorHandlingPageSection.tsx
@@ -1,0 +1,22 @@
+import React, { VoidFunctionComponent } from "react";
+import { PageSection, PageSectionProps } from "@patternfly/react-core";
+
+interface ErrorHandlingPageSectionProps {
+  children: React.ReactNode;
+}
+
+// To make sure the Handling tab layout works properly, all the PageSections inside it
+// must have the 'isFilled' prop and their height must be explicitly set to 100%
+
+const ErrorHandlingPageSection: VoidFunctionComponent<
+  ErrorHandlingPageSectionProps & Pick<PageSectionProps, "variant" | "padding">
+> = (props) => {
+  const { children, ...rest } = props;
+  return (
+    <PageSection isFilled className={"pf-u-h-100"} {...rest}>
+      {children}
+    </PageSection>
+  );
+};
+
+export default ErrorHandlingPageSection;

--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.css
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.css
@@ -1,0 +1,4 @@
+.error-handling-tab__page-section {
+  height: 100%;
+  position: relative;
+}

--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.css
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.css
@@ -1,4 +1,0 @@
-.error-handling-tab__page-section {
-  height: 100%;
-  position: relative;
-}

--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
@@ -18,6 +18,7 @@ import {
 } from "@openapi/generated/errorHelpers";
 import { APIErrorCodes } from "@openapi/generated/errors";
 import { useHistory } from "react-router-dom";
+import { PageSection } from "@patternfly/react-core";
 
 interface ErrorHandlingTabContentProps {
   bridge?: BridgeResponse;
@@ -155,7 +156,7 @@ export const ErrorHandlingTabContent = ({
     apiError !== undefined;
 
   return (
-    <>
+    <PageSection isFilled className={"pf-u-h-100"}>
       {isEditing ? (
         <ErrorHandlingEdit
           getSchema={getSchemaByMethod}
@@ -181,6 +182,6 @@ export const ErrorHandlingTabContent = ({
           isEditDisabled={editIsDisabled}
         />
       )}
-    </>
+    </PageSection>
   );
 };

--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
@@ -155,12 +155,6 @@ export const ErrorHandlingTabContent = ({
     apiError !== undefined;
 
   return (
-    // <PageSection
-    //   variant={PageSectionVariants.light}
-    //   isFilled
-    //   padding={{ default: "noPadding" }}
-    //   className={"pf-u-h-100"}
-    // >
     <>
       {isEditing ? (
         <ErrorHandlingEdit
@@ -188,6 +182,5 @@ export const ErrorHandlingTabContent = ({
         />
       )}
     </>
-    // </PageSection>
   );
 };

--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
@@ -19,6 +19,7 @@ import {
 } from "@openapi/generated/errorHelpers";
 import { APIErrorCodes } from "@openapi/generated/errors";
 import { useHistory } from "react-router-dom";
+import "./ErrorHandlingTabContent.css";
 
 interface ErrorHandlingTabContentProps {
   bridge?: BridgeResponse;
@@ -157,11 +158,9 @@ export const ErrorHandlingTabContent = ({
 
   return (
     <PageSection
-      // className="instance-page__tabs-error-handling__section"
       variant={PageSectionVariants.light}
       isFilled
-      className={"pf-u-h-100"}
-      style={{ position: "relative" }}
+      className={"error-handling-tab__page-section"}
     >
       {isEditing ? (
         <ErrorHandlingEdit

--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
@@ -18,7 +18,7 @@ import {
 } from "@openapi/generated/errorHelpers";
 import { APIErrorCodes } from "@openapi/generated/errors";
 import { useHistory } from "react-router-dom";
-import { PageSection } from "@patternfly/react-core";
+import ErrorHandlingPageSection from "@app/Instance/ErrorHandling/ErrorHandlingPageSection";
 
 interface ErrorHandlingTabContentProps {
   bridge?: BridgeResponse;
@@ -156,7 +156,7 @@ export const ErrorHandlingTabContent = ({
     apiError !== undefined;
 
   return (
-    <PageSection isFilled className={"pf-u-h-100"}>
+    <ErrorHandlingPageSection>
       {isEditing ? (
         <ErrorHandlingEdit
           getSchema={getSchemaByMethod}
@@ -182,6 +182,6 @@ export const ErrorHandlingTabContent = ({
           isEditDisabled={editIsDisabled}
         />
       )}
-    </PageSection>
+    </ErrorHandlingPageSection>
   );
 };

--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
@@ -1,4 +1,3 @@
-import { PageSection, PageSectionVariants } from "@patternfly/react-core";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "@rhoas/app-services-ui-components";
 import { useGetSchemaApi } from "../../../hooks/useSchemasApi/useGetSchemaApi";
@@ -19,7 +18,6 @@ import {
 } from "@openapi/generated/errorHelpers";
 import { APIErrorCodes } from "@openapi/generated/errors";
 import { useHistory } from "react-router-dom";
-import "./ErrorHandlingTabContent.css";
 
 interface ErrorHandlingTabContentProps {
   bridge?: BridgeResponse;
@@ -157,11 +155,13 @@ export const ErrorHandlingTabContent = ({
     apiError !== undefined;
 
   return (
-    <PageSection
-      variant={PageSectionVariants.light}
-      isFilled
-      className={"error-handling-tab__page-section"}
-    >
+    // <PageSection
+    //   variant={PageSectionVariants.light}
+    //   isFilled
+    //   padding={{ default: "noPadding" }}
+    //   className={"pf-u-h-100"}
+    // >
+    <>
       {isEditing ? (
         <ErrorHandlingEdit
           getSchema={getSchemaByMethod}
@@ -187,6 +187,7 @@ export const ErrorHandlingTabContent = ({
           isEditDisabled={editIsDisabled}
         />
       )}
-    </PageSection>
+    </>
+    // </PageSection>
   );
 };

--- a/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
+++ b/src/app/Instance/InstancePage/ErrorHandlingTabContent.tsx
@@ -1,15 +1,4 @@
-import {
-  Button,
-  PageSection,
-  PageSectionVariants,
-  Split,
-  SplitItem,
-  Stack,
-  StackItem,
-  Text,
-  TextContent,
-  TextVariants,
-} from "@patternfly/react-core";
+import { PageSection, PageSectionVariants } from "@patternfly/react-core";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "@rhoas/app-services-ui-components";
 import { useGetSchemaApi } from "../../../hooks/useSchemasApi/useGetSchemaApi";
@@ -168,61 +157,37 @@ export const ErrorHandlingTabContent = ({
 
   return (
     <PageSection
-      className="instance-page__tabs-error-handling__section"
+      // className="instance-page__tabs-error-handling__section"
       variant={PageSectionVariants.light}
+      isFilled
+      className={"pf-u-h-100"}
+      style={{ position: "relative" }}
     >
-      <Stack hasGutter>
-        <StackItem>
-          <Split hasGutter>
-            <SplitItem isFilled>
-              <TextContent>
-                <Text
-                  component={TextVariants.h2}
-                  ouiaId="error-handling-section"
-                >
-                  {t("common.errorHandlingMethod")}
-                </Text>
-              </TextContent>
-            </SplitItem>
-            {!isEditing && (
-              <SplitItem>
-                <Button
-                  isAriaDisabled={editIsDisabled}
-                  ouiaId="edit"
-                  onClick={(): void => setIsEditing(true)}
-                >
-                  {t("common.edit")}
-                </Button>
-              </SplitItem>
-            )}
-          </Split>
-        </StackItem>
-        <StackItem>
-          {isEditing ? (
-            <ErrorHandlingEdit
-              getSchema={getSchemaByMethod}
-              isLoading={isUpdateBridgeLoading || isSchemaLoading}
-              method={bridge?.error_handler?.type}
-              onCancelEditing={onCancelEditing}
-              onSubmit={onErrorHandlingSubmit}
-              parameters={
-                bridge?.error_handler?.parameters as Record<string, unknown>
-              }
-              registerValidateParameters={registerValidateParameters}
-              apiError={apiError}
-            />
-          ) : (
-            <ErrorHandlingDetail
-              errorHandlingType={bridge?.error_handler?.type}
-              errorHandlingParameters={bridge?.error_handler?.parameters}
-              isBridgeLoading={isBridgeLoading}
-              isSchemaLoading={isSchemaLoading}
-              schema={currentSchema}
-              apiError={apiError}
-            />
-          )}
-        </StackItem>
-      </Stack>
+      {isEditing ? (
+        <ErrorHandlingEdit
+          getSchema={getSchemaByMethod}
+          isLoading={isUpdateBridgeLoading || isSchemaLoading}
+          method={bridge?.error_handler?.type}
+          onCancelEditing={onCancelEditing}
+          onSubmit={onErrorHandlingSubmit}
+          parameters={
+            bridge?.error_handler?.parameters as Record<string, unknown>
+          }
+          registerValidateParameters={registerValidateParameters}
+          apiError={apiError}
+        />
+      ) : (
+        <ErrorHandlingDetail
+          errorHandlingType={bridge?.error_handler?.type}
+          errorHandlingParameters={bridge?.error_handler?.parameters}
+          isBridgeLoading={isBridgeLoading}
+          isSchemaLoading={isSchemaLoading}
+          schema={currentSchema}
+          apiError={apiError}
+          onEdit={(): void => setIsEditing(true)}
+          isEditDisabled={editIsDisabled}
+        />
+      )}
     </PageSection>
   );
 };

--- a/src/app/Instance/InstancePage/InstancePage.css
+++ b/src/app/Instance/InstancePage/InstancePage.css
@@ -5,3 +5,9 @@
 .instance-page__actions .pf-c-dropdown__menu {
   min-width: 13rem;
 }
+
+/* making the error handling PF tab fill the available vertical space*/
+#instance-page__tabs-error-handling {
+  flex-grow: 1;
+  height: 100%;
+}

--- a/src/app/Instance/InstancePage/InstancePage.css
+++ b/src/app/Instance/InstancePage/InstancePage.css
@@ -5,7 +5,3 @@
 .instance-page__actions .pf-c-dropdown__menu {
   min-width: 13rem;
 }
-
-.instance-page__tabs-error-handling__section {
-  min-height: 37rem;
-}

--- a/src/app/Instance/InstancePage/InstancePage.tsx
+++ b/src/app/Instance/InstancePage/InstancePage.tsx
@@ -273,7 +273,7 @@ const InstancePage = (): JSX.Element => {
           id={`tabContent${INSTANCE_PAGE_TAB_KEYS.processors}`}
           activeKey={activeTabKey}
         >
-          {INSTANCE_PAGE_TAB_KEYS.processors === activeTabKey && (
+          {activeTabKey === INSTANCE_PAGE_TAB_KEYS.processors && (
             <ProcessorsTabContent
               instanceId={instanceId}
               pageTitle={getPageTitle(bridge)}
@@ -287,7 +287,7 @@ const InstancePage = (): JSX.Element => {
           activeKey={activeTabKey}
           className={"pf-m-fill pf-c-page__main-section"}
         >
-          {INSTANCE_PAGE_TAB_KEYS["error-handling"] === activeTabKey && (
+          {activeTabKey === INSTANCE_PAGE_TAB_KEYS["error-handling"] && (
             <ErrorHandlingTabContent
               bridge={bridge}
               isBridgeLoading={isBridgeLoading}

--- a/src/app/Instance/InstancePage/InstancePage.tsx
+++ b/src/app/Instance/InstancePage/InstancePage.tsx
@@ -15,6 +15,7 @@ import {
   Split,
   SplitItem,
   Tab,
+  TabContent,
   Tabs,
   TabTitleText,
   Text,
@@ -234,8 +235,6 @@ const InstancePage = (): JSX.Element => {
         )}
         <PageSection variant={PageSectionVariants.light} type="tabs">
           <Tabs
-            mountOnEnter
-            unmountOnExit
             className="instance-page__tabs"
             ouiaId="instance-details"
             usePageInsets
@@ -253,14 +252,7 @@ const InstancePage = (): JSX.Element => {
                   <TabTitleText>{t("common.processors")}</TabTitleText>
                 )
               }
-            >
-              <PageSection>
-                <ProcessorsTabContent
-                  instanceId={instanceId}
-                  pageTitle={getPageTitle(bridge)}
-                />
-              </PageSection>
-            </Tab>
+            />
             <Tab
               eventKey={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
               ouiaId="error-handling"
@@ -272,16 +264,36 @@ const InstancePage = (): JSX.Element => {
                   <TabTitleText>{t("common.errorHandling")}</TabTitleText>
                 )
               }
-            >
-              <PageSection>
-                <ErrorHandlingTabContent
-                  bridge={bridge}
-                  isBridgeLoading={isBridgeLoading}
-                />
-              </PageSection>
-            </Tab>
+            />
           </Tabs>
         </PageSection>
+        <TabContent
+          key={INSTANCE_PAGE_TAB_KEYS.processors}
+          eventKey={INSTANCE_PAGE_TAB_KEYS.processors}
+          id={`tabContent${INSTANCE_PAGE_TAB_KEYS.processors}`}
+          activeKey={activeTabKey}
+        >
+          {INSTANCE_PAGE_TAB_KEYS.processors === activeTabKey && (
+            <ProcessorsTabContent
+              instanceId={instanceId}
+              pageTitle={getPageTitle(bridge)}
+            />
+          )}
+        </TabContent>
+        <TabContent
+          key={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
+          eventKey={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
+          id={`tabContent${INSTANCE_PAGE_TAB_KEYS["error-handling"]}`}
+          activeKey={activeTabKey}
+          className={"pf-m-fill pf-c-page__main-section"}
+        >
+          {INSTANCE_PAGE_TAB_KEYS["error-handling"] === activeTabKey && (
+            <ErrorHandlingTabContent
+              bridge={bridge}
+              isBridgeLoading={isBridgeLoading}
+            />
+          )}
+        </TabContent>
         <DeleteInstance
           instanceId={bridge?.id}
           instanceName={bridge?.name}

--- a/src/app/Instance/InstancePage/InstancePage.tsx
+++ b/src/app/Instance/InstancePage/InstancePage.tsx
@@ -288,7 +288,6 @@ const InstancePage = (): JSX.Element => {
             id={"instance-page__tabs-error-handling"}
             ouiaId="error-handling"
             activeKey={activeTabKey}
-            className={"pf-c-page__main-section pf-u-h-100"}
           >
             {activeTabKey === INSTANCE_PAGE_TAB_KEYS["error-handling"] && (
               <ErrorHandlingTabContent

--- a/src/app/Instance/InstancePage/InstancePage.tsx
+++ b/src/app/Instance/InstancePage/InstancePage.tsx
@@ -271,7 +271,8 @@ const InstancePage = (): JSX.Element => {
           <TabContent
             key={INSTANCE_PAGE_TAB_KEYS.processors}
             eventKey={INSTANCE_PAGE_TAB_KEYS.processors}
-            id={`tab-content-${INSTANCE_PAGE_TAB_KEYS.processors}`}
+            id={"instance-page__tabs-processors"}
+            ouiaId="processors"
             activeKey={activeTabKey}
           >
             {activeTabKey === INSTANCE_PAGE_TAB_KEYS.processors && (
@@ -284,7 +285,8 @@ const InstancePage = (): JSX.Element => {
           <TabContent
             key={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
             eventKey={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
-            id={`tab-content-${INSTANCE_PAGE_TAB_KEYS["error-handling"]}`}
+            id={"instance-page__tabs-error-handling"}
+            ouiaId="error-handling"
             activeKey={activeTabKey}
             className={"pf-c-page__main-section pf-u-h-100"}
           >

--- a/src/app/Instance/InstancePage/InstancePage.tsx
+++ b/src/app/Instance/InstancePage/InstancePage.tsx
@@ -267,33 +267,35 @@ const InstancePage = (): JSX.Element => {
             />
           </Tabs>
         </PageSection>
-        <TabContent
-          key={INSTANCE_PAGE_TAB_KEYS.processors}
-          eventKey={INSTANCE_PAGE_TAB_KEYS.processors}
-          id={`tabContent${INSTANCE_PAGE_TAB_KEYS.processors}`}
-          activeKey={activeTabKey}
-        >
-          {activeTabKey === INSTANCE_PAGE_TAB_KEYS.processors && (
-            <ProcessorsTabContent
-              instanceId={instanceId}
-              pageTitle={getPageTitle(bridge)}
-            />
-          )}
-        </TabContent>
-        <TabContent
-          key={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
-          eventKey={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
-          id={`tabContent${INSTANCE_PAGE_TAB_KEYS["error-handling"]}`}
-          activeKey={activeTabKey}
-          className={"pf-m-fill pf-c-page__main-section"}
-        >
-          {activeTabKey === INSTANCE_PAGE_TAB_KEYS["error-handling"] && (
-            <ErrorHandlingTabContent
-              bridge={bridge}
-              isBridgeLoading={isBridgeLoading}
-            />
-          )}
-        </TabContent>
+        <PageSection isFilled padding={{ default: "noPadding" }}>
+          <TabContent
+            key={INSTANCE_PAGE_TAB_KEYS.processors}
+            eventKey={INSTANCE_PAGE_TAB_KEYS.processors}
+            id={`tab-content-${INSTANCE_PAGE_TAB_KEYS.processors}`}
+            activeKey={activeTabKey}
+          >
+            {activeTabKey === INSTANCE_PAGE_TAB_KEYS.processors && (
+              <ProcessorsTabContent
+                instanceId={instanceId}
+                pageTitle={getPageTitle(bridge)}
+              />
+            )}
+          </TabContent>
+          <TabContent
+            key={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
+            eventKey={INSTANCE_PAGE_TAB_KEYS["error-handling"]}
+            id={`tab-content-${INSTANCE_PAGE_TAB_KEYS["error-handling"]}`}
+            activeKey={activeTabKey}
+            className={"pf-c-page__main-section pf-u-h-100"}
+          >
+            {activeTabKey === INSTANCE_PAGE_TAB_KEYS["error-handling"] && (
+              <ErrorHandlingTabContent
+                bridge={bridge}
+                isBridgeLoading={isBridgeLoading}
+              />
+            )}
+          </TabContent>
+        </PageSection>
         <DeleteInstance
           instanceId={bridge?.id}
           instanceName={bridge?.name}

--- a/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
+++ b/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
@@ -7,7 +7,7 @@ import {
   Button,
   EmptyState,
   EmptyStateIcon,
-  TabContent,
+  PageSection,
   Title,
 } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons";
@@ -189,40 +189,40 @@ export const ProcessorsTabContent = ({
 
   return (
     <>
-      {processorListResponse?.items ? (
-        <TableWithPagination
-          columns={processorsOverviewColumns}
-          customToolbarElement={customToolbarElement}
-          rows={processorListResponse.items}
-          tableLabel={t(
-            "openbridgeTempDictionary:processor.processorsListTable"
-          )}
-          isLoading={areProcessorsLoading}
-          onPaginationChange={onPaginationChange}
-          pageNumber={currentPage}
-          pageSize={currentPageSize}
-          totalRows={totalRows ?? 0}
-          renderActions={({ row, ActionsColumn }): JSX.Element => (
-            <ActionsColumn items={tableActions(row)} />
-          )}
-        >
-          <EmptyState variant="large">
-            <EmptyStateIcon icon={PlusCircleIcon} />
-            <Title headingLevel="h4" size="lg">
-              {t("processor.noProcessors")}
-            </Title>
-          </EmptyState>
-        </TableWithPagination>
-      ) : (
-        <TabContent id="instance-skeleton__page__tabs-processors">
+      <PageSection isFilled padding={{ default: "padding" }}>
+        {processorListResponse?.items ? (
+          <TableWithPagination
+            columns={processorsOverviewColumns}
+            customToolbarElement={customToolbarElement}
+            rows={processorListResponse.items}
+            tableLabel={t(
+              "openbridgeTempDictionary:processor.processorsListTable"
+            )}
+            isLoading={areProcessorsLoading}
+            onPaginationChange={onPaginationChange}
+            pageNumber={currentPage}
+            pageSize={currentPageSize}
+            totalRows={totalRows ?? 0}
+            renderActions={({ row, ActionsColumn }): JSX.Element => (
+              <ActionsColumn items={tableActions(row)} />
+            )}
+          >
+            <EmptyState variant="large">
+              <EmptyStateIcon icon={PlusCircleIcon} />
+              <Title headingLevel="h4" size="lg">
+                {t("processor.noProcessors")}
+              </Title>
+            </EmptyState>
+          </TableWithPagination>
+        ) : (
           <TableWithPaginationSkeleton
             hasActionColumn={true}
             columns={processorsOverviewColumns}
             totalRows={currentPageSize}
             customToolbarElement={customToolbarElement}
           />
-        </TabContent>
-      )}
+        )}
+      </PageSection>
       <DeleteProcessor
         bridgeId={instanceId}
         processorId={deleteProcessorId}

--- a/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
+++ b/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
@@ -189,7 +189,7 @@ export const ProcessorsTabContent = ({
 
   return (
     <>
-      <PageSection isFilled padding={{ default: "padding" }}>
+      <PageSection isFilled>
         {processorListResponse?.items ? (
           <TableWithPagination
             columns={processorsOverviewColumns}

--- a/src/app/Processor/ProcessorEdit/ProcessorEdit.css
+++ b/src/app/Processor/ProcessorEdit/ProcessorEdit.css
@@ -3,30 +3,6 @@
   position: relative;
 }
 
-.processor-edit__container {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
-.processor-edit__outer-wrap {
-  min-height: 0;
-  /*position: relative;*/
-}
-
-.processor-edit__inner-wrap {
-  /*position: static;*/
-  min-height: 0;
-}
-
-.processor-edit__content-wrap {
-  overflow-x: hidden;
-  overflow-y: auto;
-  word-break: break-word;
-}
-
 .processor-edit__form {
   max-width: 800px;
   padding: var(--processor-edit--spacing);
@@ -39,13 +15,6 @@
 .processor-edit__form .pf-c-tile:active,
 .pf-c-tile.pf-m-selected {
   --pf-c-tile--TranslateY: 0;
-}
-
-.processor-edit__actions {
-  margin: 0 var(--processor-edit--spacing);
-  padding: var(--processor-edit--spacing) 0;
-  width: 100%;
-  border-top: 1px solid var(--pf-global--BorderColor--100);
 }
 
 .processor-edit__transformation-template.processor-field-error {

--- a/src/app/Processor/ProcessorEdit/ProcessorEdit.css
+++ b/src/app/Processor/ProcessorEdit/ProcessorEdit.css
@@ -1,11 +1,6 @@
-.processor-edit__page-section {
-  --processor-edit--spacing: var(--pf-global--spacer--lg);
-  position: relative;
-}
-
 .processor-edit__form {
   max-width: 800px;
-  padding: var(--processor-edit--spacing);
+  padding: var(--pf-global--spacer--lg);
 }
 
 .processor-edit__form__notice {

--- a/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
+++ b/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
@@ -11,8 +11,6 @@ import {
   Alert,
   AlertGroup,
   Button,
-  Flex,
-  FlexItem,
   Form,
   FormGroup,
   FormSection,
@@ -58,6 +56,7 @@ import { ActionModal } from "@app/components/ActionModal/ActionModal";
 import { css } from "@patternfly/react-styles";
 import { HelpIcon } from "@patternfly/react-icons";
 import { ExternalLink } from "@rhoas/app-services-ui-components";
+import StickyActionsLayout from "@app/components/StickyActionsLayout/StickyActionsLayout";
 
 export interface ProcessorEditProps {
   /** The processor data to populate the form. Used when updating an existing processor.
@@ -255,310 +254,258 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
         padding={{ default: "noPadding" }}
         className="processor-edit__page-section"
       >
-        <section className={"processor-edit__container"}>
-          <Flex direction={{ default: "column" }} style={{ height: "100%" }}>
-            <Flex
-              direction={{ default: "column" }}
-              grow={{ default: "grow" }}
-              flexWrap={{ default: "nowrap" }}
-              className={"processor-edit__outer-wrap"}
+        <StickyActionsLayout
+          actions={
+            <ActionGroup>
+              <Button
+                variant="primary"
+                ouiaId="submit"
+                onClick={handleSubmit}
+                isLoading={isLoading}
+                isDisabled={isLoading}
+              >
+                {saveButtonLabel}
+              </Button>
+              <Button
+                variant="link"
+                ouiaId="cancel"
+                onClick={onCancel}
+                isDisabled={isLoading}
+              >
+                {t("common.cancel")}
+              </Button>
+            </ActionGroup>
+          }
+        >
+          <Form className={"processor-edit__form"} autoComplete="off">
+            <FormSection
+              title={t("processor.generalInformation")}
+              titleElement="h2"
             >
-              <Flex
-                direction={{ default: "column" }}
-                grow={{ default: "grow" }}
-                className={"processor-edit__inner-wrap"}
-              >
-                <FlexItem
-                  grow={{ default: "grow" }}
-                  className={"processor-edit__content-wrap"}
+              {isExistingProcessor ? (
+                <Stack>
+                  <StackItem>
+                    <FormGroup
+                      label={t("processor.processorType")}
+                      fieldId={"processor-type"}
+                    />
+                  </StackItem>
+                  <StackItem>
+                    <Label color={"blue"} data-testid="processor-type-label">
+                      {processor?.type && t(`processor.${processor.type}`)}
+                    </Label>
+                  </StackItem>
+                </Stack>
+              ) : (
+                <FormGroup
+                  label={t("processor.selectProcessorType")}
+                  fieldId={"processor-type"}
+                  isRequired
+                  helperTextInvalid={validation.errors.processorType}
+                  validated={
+                    validation.errors.processorType ? "error" : "default"
+                  }
+                  className={
+                    validation.errors.processorType && "processor-field-error"
+                  }
                 >
-                  <Form className={"processor-edit__form"} autoComplete="off">
-                    <FormSection
-                      title={t("processor.generalInformation")}
-                      titleElement="h2"
-                    >
-                      {isExistingProcessor ? (
-                        <Stack>
-                          <StackItem>
-                            <FormGroup
-                              label={t("processor.processorType")}
-                              fieldId={"processor-type"}
-                            />
-                          </StackItem>
-                          <StackItem>
-                            <Label
-                              color={"blue"}
-                              data-testid="processor-type-label"
-                            >
-                              {processor?.type &&
-                                t(`processor.${processor.type}`)}
-                            </Label>
-                          </StackItem>
-                        </Stack>
-                      ) : (
-                        <FormGroup
-                          label={t("processor.selectProcessorType")}
-                          fieldId={"processor-type"}
-                          isRequired
-                          helperTextInvalid={validation.errors.processorType}
-                          validated={
-                            validation.errors.processorType
-                              ? "error"
-                              : "default"
-                          }
-                          className={
-                            validation.errors.processorType &&
-                            "processor-field-error"
-                          }
-                        >
-                          <Grid
-                            hasGutter={true}
-                            className={"processor-form__type-selection"}
-                          >
-                            <GridItem span={6}>
-                              <Tile
-                                title={t("processor.sourceProcessor")}
-                                data-ouia-component-id="source"
-                                data-ouia-component-type="Tile"
-                                isSelected={
-                                  processorType === ProcessorType.Source
-                                }
-                                style={{ height: "100%" }}
-                                onClick={(): void => {
-                                  setProcessorType(ProcessorType.Source);
-                                  resetValidation("processorType");
-                                }}
-                              >
-                                {t("processor.sourceProcessorDescription")}
-                              </Tile>
-                            </GridItem>
-                            <GridItem span={6}>
-                              <Tile
-                                title={t("processor.sinkProcessor")}
-                                data-ouia-component-id="sink"
-                                data-ouia-component-type="Tile"
-                                style={{ width: "100%", height: "100%" }}
-                                isSelected={
-                                  processorType === ProcessorType.Sink
-                                }
-                                onClick={(): void => {
-                                  setProcessorType(ProcessorType.Sink);
-                                  resetValidation("processorType");
-                                }}
-                              >
-                                {t("processor.sinkProcessorDescription")}
-                              </Tile>
-                            </GridItem>
-                          </Grid>
-                        </FormGroup>
-                      )}
-                      <FormGroup
-                        fieldId={"processor-name"}
-                        label={t("processor.processorName")}
-                        isRequired={true}
-                        helperTextInvalid={validation.errors.name}
-                        validated={validation.errors.name ? "error" : "default"}
-                        className={
-                          validation.errors.name && "processor-field-error"
-                        }
+                  <Grid
+                    hasGutter={true}
+                    className={"processor-form__type-selection"}
+                  >
+                    <GridItem span={6}>
+                      <Tile
+                        title={t("processor.sourceProcessor")}
+                        data-ouia-component-id="source"
+                        data-ouia-component-type="Tile"
+                        isSelected={processorType === ProcessorType.Source}
+                        style={{ height: "100%" }}
+                        onClick={(): void => {
+                          setProcessorType(ProcessorType.Source);
+                          resetValidation("processorType");
+                        }}
                       >
-                        <TextInput
-                          type="text"
-                          id="processor-name"
-                          ouiaId="processor-name"
-                          name="processor-name"
-                          aria-describedby="processor-name"
-                          isRequired={true}
-                          isDisabled={isExistingProcessor}
-                          maxLength={255}
-                          value={name}
-                          onChange={setName}
-                          validated={
-                            validation.errors.name ? "error" : "default"
-                          }
-                          onBlur={(): void => {
-                            validateName();
-                          }}
-                        />
-                      </FormGroup>
-                    </FormSection>
-                    {processorType && (
-                      <>
-                        {processorType === ProcessorType.Source && (
-                          <FormSection
-                            title={t("processor.source")}
-                            data-ouia-component-id="sources"
-                            data-ouia-component-type="form-section"
-                          >
-                            <TextContent>
-                              <Text
-                                component="p"
-                                ouiaId="source-type-description"
-                              >
-                                {t(
-                                  "processor.selectSourceProcessorTypeDescription"
-                                )}
-                              </Text>
-                            </TextContent>
-                            <ConfigurationEdit
-                              configType={ProcessorSchemaType.SOURCE}
-                              source={source}
-                              registerValidation={registerValidateConfig}
-                              onChange={setSource}
-                              editMode={isExistingProcessor}
-                              schemaCatalog={schemaCatalog}
-                              schema={schema}
-                            />
-                          </FormSection>
-                        )}
-
-                        <FormSection
-                          title={t("processor.filters")}
-                          titleElement="h2"
-                        >
-                          <FiltersEdit
-                            filters={filters}
-                            onChange={setFilters}
-                          />
-                        </FormSection>
-
-                        {processorType === ProcessorType.Sink && (
-                          <>
-                            <FormSection title={t("processor.transformation")}>
-                              <TextContent>
-                                <Text
-                                  component="p"
-                                  id="transformation-description"
-                                  ouiaId="transformation-description"
-                                >
-                                  {t("processor.addTransformationDescription")}
-                                  <Popover
-                                    headerContent={t(
-                                      "processor.transformationTemplate"
-                                    )}
-                                    bodyContent={
-                                      <Trans
-                                        i18nKey={
-                                          "openbridgeTempDictionary:processor.transformationTemplateTooltip"
-                                        }
-                                        components={[
-                                          <ExternalLink
-                                            key="qute-reference-link"
-                                            testId="qute-reference-link"
-                                            href="https://quarkus.io/guides/qute-reference"
-                                          />,
-                                        ]}
-                                      />
-                                    }
-                                  >
-                                    <button
-                                      type="button"
-                                      aria-label={t(
-                                        "processor.moreInfoForTransformationTemplate"
-                                      )}
-                                      onClick={(e): void => e.preventDefault()}
-                                      aria-describedby="transformation-description"
-                                      className="pf-c-form__group-label-help"
-                                    >
-                                      <HelpIcon noVerticalAlign={true} />
-                                    </button>
-                                  </Popover>
-                                </Text>
-                              </TextContent>
-                              <CodeEditor
-                                id={"transformation-template"}
-                                className={css(
-                                  "processor-edit__transformation-template",
-                                  malformedTransformationTemplate
-                                    ? "processor-field-error"
-                                    : ""
-                                )}
-                                height={"300px"}
-                                isLineNumbersVisible={true}
-                                code={transformation}
-                                onChange={setTransformation}
-                                options={{
-                                  scrollbar: { alwaysConsumeMouseWheel: false },
-                                }}
-                              />
-                              {malformedTransformationTemplate && (
-                                <p
-                                  className="processor-edit__transformation-template__helper-text pf-c-form__helper-text pf-m-error"
-                                  aria-live="polite"
-                                >
-                                  {malformedTransformationTemplate}
-                                </p>
-                              )}
-                            </FormSection>
-                            <FormSection
-                              title={t("processor.action")}
-                              data-ouia-component-id="actions"
-                              data-ouia-component-type="form-section"
-                            >
-                              <TextContent>
-                                <Text component="p" ouiaId="action-description">
-                                  {t("processor.selectActionDescription")}
-                                </Text>
-                              </TextContent>
-                              <ConfigurationEdit
-                                configType={ProcessorSchemaType.ACTION}
-                                action={action}
-                                registerValidation={registerValidateConfig}
-                                onChange={setAction}
-                                editMode={isExistingProcessor}
-                                schemaCatalog={schemaCatalog}
-                                schema={schema}
-                              />
-                            </FormSection>
-                          </>
-                        )}
-                        {processorType && (
-                          <AlertGroup
-                            className={"processor-edit__form__notice"}
-                          >
-                            <Alert
-                              variant="info"
-                              ouiaId="info-processor-available-soon"
-                              isInline={true}
-                              isPlain={true}
-                              title={t(
-                                "processor.processorWillBeAvailableShortly"
-                              )}
-                            />
-                          </AlertGroup>
-                        )}
-                      </>
-                    )}
-                  </Form>
-                </FlexItem>
-              </Flex>
-              <Flex
-                flexWrap={{ default: "wrap" }}
-                shrink={{ default: "shrink" }}
+                        {t("processor.sourceProcessorDescription")}
+                      </Tile>
+                    </GridItem>
+                    <GridItem span={6}>
+                      <Tile
+                        title={t("processor.sinkProcessor")}
+                        data-ouia-component-id="sink"
+                        data-ouia-component-type="Tile"
+                        style={{ width: "100%", height: "100%" }}
+                        isSelected={processorType === ProcessorType.Sink}
+                        onClick={(): void => {
+                          setProcessorType(ProcessorType.Sink);
+                          resetValidation("processorType");
+                        }}
+                      >
+                        {t("processor.sinkProcessorDescription")}
+                      </Tile>
+                    </GridItem>
+                  </Grid>
+                </FormGroup>
+              )}
+              <FormGroup
+                fieldId={"processor-name"}
+                label={t("processor.processorName")}
+                isRequired={true}
+                helperTextInvalid={validation.errors.name}
+                validated={validation.errors.name ? "error" : "default"}
+                className={validation.errors.name && "processor-field-error"}
               >
-                <ActionGroup className={"processor-edit__actions"}>
-                  <Button
-                    variant="primary"
-                    ouiaId="submit"
-                    onClick={handleSubmit}
-                    isLoading={isLoading}
-                    isDisabled={isLoading}
+                <TextInput
+                  type="text"
+                  id="processor-name"
+                  ouiaId="processor-name"
+                  name="processor-name"
+                  aria-describedby="processor-name"
+                  isRequired={true}
+                  isDisabled={isExistingProcessor}
+                  maxLength={255}
+                  value={name}
+                  onChange={setName}
+                  validated={validation.errors.name ? "error" : "default"}
+                  onBlur={(): void => {
+                    validateName();
+                  }}
+                />
+              </FormGroup>
+            </FormSection>
+            {processorType && (
+              <>
+                {processorType === ProcessorType.Source && (
+                  <FormSection
+                    title={t("processor.source")}
+                    data-ouia-component-id="sources"
+                    data-ouia-component-type="form-section"
                   >
-                    {saveButtonLabel}
-                  </Button>
-                  <Button
-                    variant="link"
-                    ouiaId="cancel"
-                    onClick={onCancel}
-                    isDisabled={isLoading}
-                  >
-                    {t("common.cancel")}
-                  </Button>
-                </ActionGroup>
-              </Flex>
-            </Flex>
-          </Flex>
-        </section>
+                    <TextContent>
+                      <Text component="p" ouiaId="source-type-description">
+                        {t("processor.selectSourceProcessorTypeDescription")}
+                      </Text>
+                    </TextContent>
+                    <ConfigurationEdit
+                      configType={ProcessorSchemaType.SOURCE}
+                      source={source}
+                      registerValidation={registerValidateConfig}
+                      onChange={setSource}
+                      editMode={isExistingProcessor}
+                      schemaCatalog={schemaCatalog}
+                      schema={schema}
+                    />
+                  </FormSection>
+                )}
+
+                <FormSection title={t("processor.filters")} titleElement="h2">
+                  <FiltersEdit filters={filters} onChange={setFilters} />
+                </FormSection>
+
+                {processorType === ProcessorType.Sink && (
+                  <>
+                    <FormSection title={t("processor.transformation")}>
+                      <TextContent>
+                        <Text
+                          component="p"
+                          id="transformation-description"
+                          ouiaId="transformation-description"
+                        >
+                          {t("processor.addTransformationDescription")}
+                          <Popover
+                            headerContent={t(
+                              "processor.transformationTemplate"
+                            )}
+                            bodyContent={
+                              <Trans
+                                i18nKey={
+                                  "openbridgeTempDictionary:processor.transformationTemplateTooltip"
+                                }
+                                components={[
+                                  <ExternalLink
+                                    key="qute-reference-link"
+                                    testId="qute-reference-link"
+                                    href="https://quarkus.io/guides/qute-reference"
+                                  />,
+                                ]}
+                              />
+                            }
+                          >
+                            <button
+                              type="button"
+                              aria-label={t(
+                                "processor.moreInfoForTransformationTemplate"
+                              )}
+                              onClick={(e): void => e.preventDefault()}
+                              aria-describedby="transformation-description"
+                              className="pf-c-form__group-label-help"
+                            >
+                              <HelpIcon noVerticalAlign={true} />
+                            </button>
+                          </Popover>
+                        </Text>
+                      </TextContent>
+                      <CodeEditor
+                        id={"transformation-template"}
+                        className={css(
+                          "processor-edit__transformation-template",
+                          malformedTransformationTemplate
+                            ? "processor-field-error"
+                            : ""
+                        )}
+                        height={"300px"}
+                        isLineNumbersVisible={true}
+                        code={transformation}
+                        onChange={setTransformation}
+                        options={{
+                          scrollbar: { alwaysConsumeMouseWheel: false },
+                        }}
+                      />
+                      {malformedTransformationTemplate && (
+                        <p
+                          className="processor-edit__transformation-template__helper-text pf-c-form__helper-text pf-m-error"
+                          aria-live="polite"
+                        >
+                          {malformedTransformationTemplate}
+                        </p>
+                      )}
+                    </FormSection>
+                    <FormSection
+                      title={t("processor.action")}
+                      data-ouia-component-id="actions"
+                      data-ouia-component-type="form-section"
+                    >
+                      <TextContent>
+                        <Text component="p" ouiaId="action-description">
+                          {t("processor.selectActionDescription")}
+                        </Text>
+                      </TextContent>
+                      <ConfigurationEdit
+                        configType={ProcessorSchemaType.ACTION}
+                        action={action}
+                        registerValidation={registerValidateConfig}
+                        onChange={setAction}
+                        editMode={isExistingProcessor}
+                        schemaCatalog={schemaCatalog}
+                        schema={schema}
+                      />
+                    </FormSection>
+                  </>
+                )}
+                {processorType && (
+                  <AlertGroup className={"processor-edit__form__notice"}>
+                    <Alert
+                      variant="info"
+                      ouiaId="info-processor-available-soon"
+                      isInline={true}
+                      isPlain={true}
+                      title={t("processor.processorWillBeAvailableShortly")}
+                    />
+                  </AlertGroup>
+                )}
+              </>
+            )}
+          </Form>
+        </StickyActionsLayout>
         <ActionModal
           action={actionModalFn.current}
           message={actionModalMessage.current}

--- a/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
+++ b/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
@@ -248,272 +248,267 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
   }, [isSubmitted, malformedTransformationTemplate]);
 
   return (
-    <>
-      <PageSection
-        variant={PageSectionVariants.light}
-        padding={{ default: "noPadding" }}
-        className="processor-edit__page-section"
-      >
-        <StickyActionsLayout
-          actions={
-            <ActionGroup>
-              <Button
-                variant="primary"
-                ouiaId="submit"
-                onClick={handleSubmit}
-                isLoading={isLoading}
-                isDisabled={isLoading}
-              >
-                {saveButtonLabel}
-              </Button>
-              <Button
-                variant="link"
-                ouiaId="cancel"
-                onClick={onCancel}
-                isDisabled={isLoading}
-              >
-                {t("common.cancel")}
-              </Button>
-            </ActionGroup>
-          }
-        >
-          <Form className={"processor-edit__form"} autoComplete="off">
-            <FormSection
-              title={t("processor.generalInformation")}
-              titleElement="h2"
+    <PageSection
+      variant={PageSectionVariants.light}
+      padding={{ default: "noPadding" }}
+    >
+      <StickyActionsLayout
+        actions={
+          <ActionGroup>
+            <Button
+              variant="primary"
+              ouiaId="submit"
+              onClick={handleSubmit}
+              isLoading={isLoading}
+              isDisabled={isLoading}
             >
-              {isExistingProcessor ? (
-                <Stack>
-                  <StackItem>
-                    <FormGroup
-                      label={t("processor.processorType")}
-                      fieldId={"processor-type"}
-                    />
-                  </StackItem>
-                  <StackItem>
-                    <Label color={"blue"} data-testid="processor-type-label">
-                      {processor?.type && t(`processor.${processor.type}`)}
-                    </Label>
-                  </StackItem>
-                </Stack>
-              ) : (
-                <FormGroup
-                  label={t("processor.selectProcessorType")}
-                  fieldId={"processor-type"}
-                  isRequired
-                  helperTextInvalid={validation.errors.processorType}
-                  validated={
-                    validation.errors.processorType ? "error" : "default"
-                  }
-                  className={
-                    validation.errors.processorType && "processor-field-error"
-                  }
-                >
-                  <Grid
-                    hasGutter={true}
-                    className={"processor-form__type-selection"}
-                  >
-                    <GridItem span={6}>
-                      <Tile
-                        title={t("processor.sourceProcessor")}
-                        data-ouia-component-id="source"
-                        data-ouia-component-type="Tile"
-                        isSelected={processorType === ProcessorType.Source}
-                        style={{ height: "100%" }}
-                        onClick={(): void => {
-                          setProcessorType(ProcessorType.Source);
-                          resetValidation("processorType");
-                        }}
-                      >
-                        {t("processor.sourceProcessorDescription")}
-                      </Tile>
-                    </GridItem>
-                    <GridItem span={6}>
-                      <Tile
-                        title={t("processor.sinkProcessor")}
-                        data-ouia-component-id="sink"
-                        data-ouia-component-type="Tile"
-                        style={{ width: "100%", height: "100%" }}
-                        isSelected={processorType === ProcessorType.Sink}
-                        onClick={(): void => {
-                          setProcessorType(ProcessorType.Sink);
-                          resetValidation("processorType");
-                        }}
-                      >
-                        {t("processor.sinkProcessorDescription")}
-                      </Tile>
-                    </GridItem>
-                  </Grid>
-                </FormGroup>
-              )}
+              {saveButtonLabel}
+            </Button>
+            <Button
+              variant="link"
+              ouiaId="cancel"
+              onClick={onCancel}
+              isDisabled={isLoading}
+            >
+              {t("common.cancel")}
+            </Button>
+          </ActionGroup>
+        }
+      >
+        <Form className={"processor-edit__form"} autoComplete="off">
+          <FormSection
+            title={t("processor.generalInformation")}
+            titleElement="h2"
+          >
+            {isExistingProcessor ? (
+              <Stack>
+                <StackItem>
+                  <FormGroup
+                    label={t("processor.processorType")}
+                    fieldId={"processor-type"}
+                  />
+                </StackItem>
+                <StackItem>
+                  <Label color={"blue"} data-testid="processor-type-label">
+                    {processor?.type && t(`processor.${processor.type}`)}
+                  </Label>
+                </StackItem>
+              </Stack>
+            ) : (
               <FormGroup
-                fieldId={"processor-name"}
-                label={t("processor.processorName")}
-                isRequired={true}
-                helperTextInvalid={validation.errors.name}
-                validated={validation.errors.name ? "error" : "default"}
-                className={validation.errors.name && "processor-field-error"}
+                label={t("processor.selectProcessorType")}
+                fieldId={"processor-type"}
+                isRequired
+                helperTextInvalid={validation.errors.processorType}
+                validated={
+                  validation.errors.processorType ? "error" : "default"
+                }
+                className={
+                  validation.errors.processorType && "processor-field-error"
+                }
               >
-                <TextInput
-                  type="text"
-                  id="processor-name"
-                  ouiaId="processor-name"
-                  name="processor-name"
-                  aria-describedby="processor-name"
-                  isRequired={true}
-                  isDisabled={isExistingProcessor}
-                  maxLength={255}
-                  value={name}
-                  onChange={setName}
-                  validated={validation.errors.name ? "error" : "default"}
-                  onBlur={(): void => {
-                    validateName();
-                  }}
-                />
+                <Grid
+                  hasGutter={true}
+                  className={"processor-form__type-selection"}
+                >
+                  <GridItem span={6}>
+                    <Tile
+                      title={t("processor.sourceProcessor")}
+                      data-ouia-component-id="source"
+                      data-ouia-component-type="Tile"
+                      isSelected={processorType === ProcessorType.Source}
+                      style={{ height: "100%" }}
+                      onClick={(): void => {
+                        setProcessorType(ProcessorType.Source);
+                        resetValidation("processorType");
+                      }}
+                    >
+                      {t("processor.sourceProcessorDescription")}
+                    </Tile>
+                  </GridItem>
+                  <GridItem span={6}>
+                    <Tile
+                      title={t("processor.sinkProcessor")}
+                      data-ouia-component-id="sink"
+                      data-ouia-component-type="Tile"
+                      style={{ width: "100%", height: "100%" }}
+                      isSelected={processorType === ProcessorType.Sink}
+                      onClick={(): void => {
+                        setProcessorType(ProcessorType.Sink);
+                        resetValidation("processorType");
+                      }}
+                    >
+                      {t("processor.sinkProcessorDescription")}
+                    </Tile>
+                  </GridItem>
+                </Grid>
               </FormGroup>
-            </FormSection>
-            {processorType && (
-              <>
-                {processorType === ProcessorType.Source && (
+            )}
+            <FormGroup
+              fieldId={"processor-name"}
+              label={t("processor.processorName")}
+              isRequired={true}
+              helperTextInvalid={validation.errors.name}
+              validated={validation.errors.name ? "error" : "default"}
+              className={validation.errors.name && "processor-field-error"}
+            >
+              <TextInput
+                type="text"
+                id="processor-name"
+                ouiaId="processor-name"
+                name="processor-name"
+                aria-describedby="processor-name"
+                isRequired={true}
+                isDisabled={isExistingProcessor}
+                maxLength={255}
+                value={name}
+                onChange={setName}
+                validated={validation.errors.name ? "error" : "default"}
+                onBlur={(): void => {
+                  validateName();
+                }}
+              />
+            </FormGroup>
+          </FormSection>
+          {processorType && (
+            <>
+              {processorType === ProcessorType.Source && (
+                <FormSection
+                  title={t("processor.source")}
+                  data-ouia-component-id="sources"
+                  data-ouia-component-type="form-section"
+                >
+                  <TextContent>
+                    <Text component="p" ouiaId="source-type-description">
+                      {t("processor.selectSourceProcessorTypeDescription")}
+                    </Text>
+                  </TextContent>
+                  <ConfigurationEdit
+                    configType={ProcessorSchemaType.SOURCE}
+                    source={source}
+                    registerValidation={registerValidateConfig}
+                    onChange={setSource}
+                    editMode={isExistingProcessor}
+                    schemaCatalog={schemaCatalog}
+                    schema={schema}
+                  />
+                </FormSection>
+              )}
+
+              <FormSection title={t("processor.filters")} titleElement="h2">
+                <FiltersEdit filters={filters} onChange={setFilters} />
+              </FormSection>
+
+              {processorType === ProcessorType.Sink && (
+                <>
+                  <FormSection title={t("processor.transformation")}>
+                    <TextContent>
+                      <Text
+                        component="p"
+                        id="transformation-description"
+                        ouiaId="transformation-description"
+                      >
+                        {t("processor.addTransformationDescription")}
+                        <Popover
+                          headerContent={t("processor.transformationTemplate")}
+                          bodyContent={
+                            <Trans
+                              i18nKey={
+                                "openbridgeTempDictionary:processor.transformationTemplateTooltip"
+                              }
+                              components={[
+                                <ExternalLink
+                                  key="qute-reference-link"
+                                  testId="qute-reference-link"
+                                  href="https://quarkus.io/guides/qute-reference"
+                                />,
+                              ]}
+                            />
+                          }
+                        >
+                          <button
+                            type="button"
+                            aria-label={t(
+                              "processor.moreInfoForTransformationTemplate"
+                            )}
+                            onClick={(e): void => e.preventDefault()}
+                            aria-describedby="transformation-description"
+                            className="pf-c-form__group-label-help"
+                          >
+                            <HelpIcon noVerticalAlign={true} />
+                          </button>
+                        </Popover>
+                      </Text>
+                    </TextContent>
+                    <CodeEditor
+                      id={"transformation-template"}
+                      className={css(
+                        "processor-edit__transformation-template",
+                        malformedTransformationTemplate
+                          ? "processor-field-error"
+                          : ""
+                      )}
+                      height={"300px"}
+                      isLineNumbersVisible={true}
+                      code={transformation}
+                      onChange={setTransformation}
+                      options={{
+                        scrollbar: { alwaysConsumeMouseWheel: false },
+                      }}
+                    />
+                    {malformedTransformationTemplate && (
+                      <p
+                        className="processor-edit__transformation-template__helper-text pf-c-form__helper-text pf-m-error"
+                        aria-live="polite"
+                      >
+                        {malformedTransformationTemplate}
+                      </p>
+                    )}
+                  </FormSection>
                   <FormSection
-                    title={t("processor.source")}
-                    data-ouia-component-id="sources"
+                    title={t("processor.action")}
+                    data-ouia-component-id="actions"
                     data-ouia-component-type="form-section"
                   >
                     <TextContent>
-                      <Text component="p" ouiaId="source-type-description">
-                        {t("processor.selectSourceProcessorTypeDescription")}
+                      <Text component="p" ouiaId="action-description">
+                        {t("processor.selectActionDescription")}
                       </Text>
                     </TextContent>
                     <ConfigurationEdit
-                      configType={ProcessorSchemaType.SOURCE}
-                      source={source}
+                      configType={ProcessorSchemaType.ACTION}
+                      action={action}
                       registerValidation={registerValidateConfig}
-                      onChange={setSource}
+                      onChange={setAction}
                       editMode={isExistingProcessor}
                       schemaCatalog={schemaCatalog}
                       schema={schema}
                     />
                   </FormSection>
-                )}
-
-                <FormSection title={t("processor.filters")} titleElement="h2">
-                  <FiltersEdit filters={filters} onChange={setFilters} />
-                </FormSection>
-
-                {processorType === ProcessorType.Sink && (
-                  <>
-                    <FormSection title={t("processor.transformation")}>
-                      <TextContent>
-                        <Text
-                          component="p"
-                          id="transformation-description"
-                          ouiaId="transformation-description"
-                        >
-                          {t("processor.addTransformationDescription")}
-                          <Popover
-                            headerContent={t(
-                              "processor.transformationTemplate"
-                            )}
-                            bodyContent={
-                              <Trans
-                                i18nKey={
-                                  "openbridgeTempDictionary:processor.transformationTemplateTooltip"
-                                }
-                                components={[
-                                  <ExternalLink
-                                    key="qute-reference-link"
-                                    testId="qute-reference-link"
-                                    href="https://quarkus.io/guides/qute-reference"
-                                  />,
-                                ]}
-                              />
-                            }
-                          >
-                            <button
-                              type="button"
-                              aria-label={t(
-                                "processor.moreInfoForTransformationTemplate"
-                              )}
-                              onClick={(e): void => e.preventDefault()}
-                              aria-describedby="transformation-description"
-                              className="pf-c-form__group-label-help"
-                            >
-                              <HelpIcon noVerticalAlign={true} />
-                            </button>
-                          </Popover>
-                        </Text>
-                      </TextContent>
-                      <CodeEditor
-                        id={"transformation-template"}
-                        className={css(
-                          "processor-edit__transformation-template",
-                          malformedTransformationTemplate
-                            ? "processor-field-error"
-                            : ""
-                        )}
-                        height={"300px"}
-                        isLineNumbersVisible={true}
-                        code={transformation}
-                        onChange={setTransformation}
-                        options={{
-                          scrollbar: { alwaysConsumeMouseWheel: false },
-                        }}
-                      />
-                      {malformedTransformationTemplate && (
-                        <p
-                          className="processor-edit__transformation-template__helper-text pf-c-form__helper-text pf-m-error"
-                          aria-live="polite"
-                        >
-                          {malformedTransformationTemplate}
-                        </p>
-                      )}
-                    </FormSection>
-                    <FormSection
-                      title={t("processor.action")}
-                      data-ouia-component-id="actions"
-                      data-ouia-component-type="form-section"
-                    >
-                      <TextContent>
-                        <Text component="p" ouiaId="action-description">
-                          {t("processor.selectActionDescription")}
-                        </Text>
-                      </TextContent>
-                      <ConfigurationEdit
-                        configType={ProcessorSchemaType.ACTION}
-                        action={action}
-                        registerValidation={registerValidateConfig}
-                        onChange={setAction}
-                        editMode={isExistingProcessor}
-                        schemaCatalog={schemaCatalog}
-                        schema={schema}
-                      />
-                    </FormSection>
-                  </>
-                )}
-                {processorType && (
-                  <AlertGroup className={"processor-edit__form__notice"}>
-                    <Alert
-                      variant="info"
-                      ouiaId="info-processor-available-soon"
-                      isInline={true}
-                      isPlain={true}
-                      title={t("processor.processorWillBeAvailableShortly")}
-                    />
-                  </AlertGroup>
-                )}
-              </>
-            )}
-          </Form>
-        </StickyActionsLayout>
-        <ActionModal
-          action={actionModalFn.current}
-          message={actionModalMessage.current}
-          showDialog={showActionModal}
-          title={t("processor.errors.cantCreateProcessor")}
-        />
-      </PageSection>
-    </>
+                </>
+              )}
+              {processorType && (
+                <AlertGroup className={"processor-edit__form__notice"}>
+                  <Alert
+                    variant="info"
+                    ouiaId="info-processor-available-soon"
+                    isInline={true}
+                    isPlain={true}
+                    title={t("processor.processorWillBeAvailableShortly")}
+                  />
+                </AlertGroup>
+              )}
+            </>
+          )}
+        </Form>
+      </StickyActionsLayout>
+      <ActionModal
+        action={actionModalFn.current}
+        message={actionModalMessage.current}
+        showDialog={showActionModal}
+        title={t("processor.errors.cantCreateProcessor")}
+      />
+    </PageSection>
   );
 };
 

--- a/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
+++ b/src/app/Processor/ProcessorEdit/ProcessorEdit.tsx
@@ -274,6 +274,7 @@ const ProcessorEdit = (props: ProcessorEditProps): JSX.Element => {
             </Button>
           </ActionGroup>
         }
+        contentId={"processor-form-container"}
       >
         <Form className={"processor-edit__form"} autoComplete="off">
           <FormSection

--- a/src/app/Processor/ProcessorEdit/ProcessorEditSkeleton.tsx
+++ b/src/app/Processor/ProcessorEdit/ProcessorEditSkeleton.tsx
@@ -16,7 +16,6 @@ const ProcessorEditSkeleton = (): JSX.Element => {
     <PageSection
       variant={PageSectionVariants.light}
       padding={{ default: "noPadding" }}
-      className="processor-edit__page-section"
     >
       <section className="processor-edit__form">
         <Flex

--- a/src/app/components/StickyActionsLayout/StickyActionsLayout.css
+++ b/src/app/components/StickyActionsLayout/StickyActionsLayout.css
@@ -1,0 +1,25 @@
+.sticky-actions__container {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.sticky-actions__outer-wrap,
+.sticky-actions__inner-wrap {
+  min-height: 0;
+}
+
+.sticky-actions__content-wrap {
+  overflow-x: hidden;
+  overflow-y: auto;
+  word-break: break-word;
+}
+
+.sticky-actions__actions {
+  margin: 0 var(--pf-global--spacer--lg);
+  padding: var(--pf-global--spacer--lg) 0;
+  width: 100%;
+  border-top: 1px solid var(--pf-global--BorderColor--100);
+}

--- a/src/app/components/StickyActionsLayout/StickyActionsLayout.css
+++ b/src/app/components/StickyActionsLayout/StickyActionsLayout.css
@@ -1,4 +1,9 @@
-.sticky-actions__container {
+.sticky-actions-layout {
+  height: 100%;
+  position: relative;
+}
+
+.sticky-actions-layout__container {
   position: absolute;
   top: 0;
   right: 0;
@@ -6,22 +11,22 @@
   left: 0;
 }
 
-.sticky-actions__root-flex {
+.sticky-actions-layout__root-flex {
   height: 100%;
 }
 
-.sticky-actions__outer-wrap,
-.sticky-actions__inner-wrap {
+.sticky-actions-layout__outer-wrap,
+.sticky-actions-layout__inner-wrap {
   min-height: 0;
 }
 
-.sticky-actions__content-wrap {
+.sticky-actions-layout__content-wrap {
   overflow-x: hidden;
   overflow-y: auto;
   word-break: break-word;
 }
 
-.sticky-actions__actions {
+.sticky-actions-layout__actions {
   margin: 0 var(--pf-global--spacer--lg);
   padding: var(--pf-global--spacer--lg) 0;
   width: 100%;

--- a/src/app/components/StickyActionsLayout/StickyActionsLayout.css
+++ b/src/app/components/StickyActionsLayout/StickyActionsLayout.css
@@ -6,6 +6,10 @@
   left: 0;
 }
 
+.sticky-actions__root-flex {
+  height: 100%;
+}
+
 .sticky-actions__outer-wrap,
 .sticky-actions__inner-wrap {
   min-height: 0;

--- a/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
+++ b/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
@@ -3,7 +3,9 @@ import { Flex, FlexItem } from "@patternfly/react-core";
 import "./StickyActionsLayout.css";
 
 interface StickyActionsLayoutProps {
+  /** The element(s) rendered in the body of the layout (like a form) */
   children: React.ReactNode;
+  /** The element(s) rendered in the fixed bottom area (like a form actions buttons) */
   actions: React.ReactNode;
 }
 
@@ -12,37 +14,39 @@ const StickyActionsLayout: VoidFunctionComponent<StickyActionsLayoutProps> = (
 ) => {
   const { children, actions } = props;
   return (
-    <div>
-      <section className={"sticky-actions__container"}>
+    <section className={"sticky-actions-layout"}>
+      <section className={"sticky-actions-layout__container"}>
         <Flex
           direction={{ default: "column" }}
-          className={"sticky-actions__root-flex"}
+          className={"sticky-actions-layout__root-flex"}
         >
           <Flex
             direction={{ default: "column" }}
             grow={{ default: "grow" }}
             flexWrap={{ default: "nowrap" }}
-            className={"sticky-actions__outer-wrap"}
+            className={"sticky-actions-layout__outer-wrap"}
           >
             <Flex
               direction={{ default: "column" }}
               grow={{ default: "grow" }}
-              className={"sticky-actions__inner-wrap"}
+              className={"sticky-actions-layout__inner-wrap"}
             >
               <FlexItem
                 grow={{ default: "grow" }}
-                className={"sticky-actions__content-wrap"}
+                className={"sticky-actions-layout__content-wrap"}
               >
                 {children}
               </FlexItem>
             </Flex>
             <Flex flexWrap={{ default: "wrap" }} shrink={{ default: "shrink" }}>
-              <section className={"sticky-actions__actions"}>{actions}</section>
+              <section className={"sticky-actions-layout__actions"}>
+                {actions}
+              </section>
             </Flex>
           </Flex>
         </Flex>
       </section>
-    </div>
+    </section>
   );
 };
 

--- a/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
+++ b/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
@@ -1,0 +1,53 @@
+import React, { FunctionComponent } from "react";
+import { Flex, FlexItem } from "@patternfly/react-core";
+import "./StickyActionsLayout.css";
+
+interface StickyActionsLayoutProps {
+  children: React.ReactNode;
+  actions: React.ReactNode;
+}
+
+const StickyActionsLayout: FunctionComponent<StickyActionsLayoutProps> = (
+  props
+) => {
+  const { children, actions } = props;
+  return (
+    <div>
+      <section className={"sticky-actions__container"}>
+        <Flex direction={{ default: "column" }} style={{ height: "100%" }}>
+          <Flex
+            direction={{ default: "column" }}
+            grow={{ default: "grow" }}
+            flexWrap={{ default: "nowrap" }}
+            className={"sticky-actions__outer-wrap"}
+          >
+            <Flex
+              direction={{ default: "column" }}
+              grow={{ default: "grow" }}
+              className={"sticky-actions__inner-wrap"}
+            >
+              <FlexItem
+                grow={{ default: "grow" }}
+                className={"sticky-actions__content-wrap"}
+              >
+                {children}
+                {/*<Form*/}
+                {/*  className={"sticky-actions__form"}*/}
+                {/*  autoComplete="off"*/}
+                {/*></Form>*/}
+              </FlexItem>
+            </Flex>
+            <Flex flexWrap={{ default: "wrap" }} shrink={{ default: "shrink" }}>
+              {/*<ActionGroup className={"processor-edit__actions"}>*/}
+              {/*  */}
+              {/*</ActionGroup>*/}
+              <section className={"sticky-actions__actions"}>{actions}</section>
+            </Flex>
+          </Flex>
+        </Flex>
+      </section>
+    </div>
+  );
+};
+
+export default StickyActionsLayout;

--- a/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
+++ b/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
@@ -11,6 +11,9 @@ interface StickyActionsLayoutProps {
   contentId?: string;
 }
 
+// Note that for the StickyActionsLayout to properly work, its parent element must
+// have its height explicitly set (with absolute or relative values)
+
 const StickyActionsLayout: VoidFunctionComponent<StickyActionsLayoutProps> = (
   props
 ) => {

--- a/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
+++ b/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
@@ -3,16 +3,18 @@ import { Flex, FlexItem } from "@patternfly/react-core";
 import "./StickyActionsLayout.css";
 
 interface StickyActionsLayoutProps {
-  /** The element(s) rendered in the body of the layout (like a form) */
+  /** The element(s) rendered in the main content area of the layout (like a form) */
   children: React.ReactNode;
   /** The element(s) rendered in the fixed bottom area (like a form actions buttons) */
   actions: React.ReactNode;
+  /** Id to assign to the scrollable main content container (mainly for test purposes) */
+  contentId?: string;
 }
 
 const StickyActionsLayout: VoidFunctionComponent<StickyActionsLayoutProps> = (
   props
 ) => {
-  const { children, actions } = props;
+  const { children, actions, contentId = "scrollable-area" } = props;
   return (
     <section className={"sticky-actions-layout"}>
       <section className={"sticky-actions-layout__container"}>
@@ -34,6 +36,7 @@ const StickyActionsLayout: VoidFunctionComponent<StickyActionsLayoutProps> = (
               <FlexItem
                 grow={{ default: "grow" }}
                 className={"sticky-actions-layout__content-wrap"}
+                id={contentId}
               >
                 {children}
               </FlexItem>

--- a/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
+++ b/src/app/components/StickyActionsLayout/StickyActionsLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react";
+import React, { VoidFunctionComponent } from "react";
 import { Flex, FlexItem } from "@patternfly/react-core";
 import "./StickyActionsLayout.css";
 
@@ -7,14 +7,17 @@ interface StickyActionsLayoutProps {
   actions: React.ReactNode;
 }
 
-const StickyActionsLayout: FunctionComponent<StickyActionsLayoutProps> = (
+const StickyActionsLayout: VoidFunctionComponent<StickyActionsLayoutProps> = (
   props
 ) => {
   const { children, actions } = props;
   return (
     <div>
       <section className={"sticky-actions__container"}>
-        <Flex direction={{ default: "column" }} style={{ height: "100%" }}>
+        <Flex
+          direction={{ default: "column" }}
+          className={"sticky-actions__root-flex"}
+        >
           <Flex
             direction={{ default: "column" }}
             grow={{ default: "grow" }}
@@ -31,16 +34,9 @@ const StickyActionsLayout: FunctionComponent<StickyActionsLayoutProps> = (
                 className={"sticky-actions__content-wrap"}
               >
                 {children}
-                {/*<Form*/}
-                {/*  className={"sticky-actions__form"}*/}
-                {/*  autoComplete="off"*/}
-                {/*></Form>*/}
               </FlexItem>
             </Flex>
             <Flex flexWrap={{ default: "wrap" }} shrink={{ default: "shrink" }}>
-              {/*<ActionGroup className={"processor-edit__actions"}>*/}
-              {/*  */}
-              {/*</ActionGroup>*/}
               <section className={"sticky-actions__actions"}>{actions}</section>
             </Flex>
           </Flex>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-1129

This PR implements the "full height layout with fixed actions" for the error handling tab of bridges.

I did some investigation before starting working on it. 

PF offers a "sticky actions" solution with the `PageSection` component ([example](https://www.patternfly.org/v4/components/page/html-demos/#sticky-section-bottom)). In order to use it though, the involved `PageSection`'s need to be all at the same _root_ level. In our case, the EH actions are deep down in the tree from where the page layout resides (`InstancePage` :arrow_right: `ErrorHandlingTabContent` :arrow_right: `ErrorHandlingEdit`). Another hurdle comes with the presence of PF `Tabs` within `InstancePage`, because each `Tab` interfere with [filled](https://www.patternfly.org/v4/components/page#with-or-without-fill) `PageSection`'s behavior.

The only option I saw was a "custom" layout implementation. We did a similar thing for the "Processor edit" page, where actions are fixed at the bottom of the viewport. I opted for extracting this layout into a separate component, `StickyActionsLayout`, and reuse it for the EH too.

Doing so I had to change a bunch of things around unfortunately. I'll add some review comments to describe what's happening where.

I'm not particularly happy about the amount of changes I had to make, some of them not so self-explanatory. 

Let me know what you think. 


