### PR TITLE
MGDOBR-1196: "Create bridge" dialog hangs after API unexpected managed errors

### DIFF
--- a/cypress/integration/instance/InstanceCreation.ts
+++ b/cypress/integration/instance/InstanceCreation.ts
@@ -96,6 +96,7 @@ describe("the 'Create a SE instance' Modal", () => {
       });
   });
 
+  // instance with name "error-test" already exists
   it("Submit and expect error", () => {
     const errorInstanceName: string = "error-test";
     cy.ouiaId("create-smart-event-instance", "PF4/Button").click();
@@ -113,20 +114,40 @@ describe("the 'Create a SE instance' Modal", () => {
     });
   });
 
-  it("Submit and expect quoata error", () => {
-    const errorInstanceName: string = "quota-error";
-    cy.ouiaId("create-smart-event-instance", "PF4/Button").click();
-    cy.ouiaId("create-instance", "PF4/ModalContent").then(($modal) => {
-      cy.wrap($modal)
-        .should("be.visible")
-        .within(() => {
-          cy.ouiaId("new-name", "PF4/TextInput").type(errorInstanceName);
-          cy.ouiaId("submit", "PF4/Button").click();
-          cy.ouiaId("error-instance-create-fail", "PF4/Alert").should(
-            "contain.text",
-            "Warning alert:Your organization is out of quota."
-          );
-        });
+  onlyOn(isEnvironmentType(EnvType.Mocked), () => {
+    // instance with name containing "error-test" causes 4xx response code
+    it("Submit and expect error while creating", () => {
+      const errorInstanceName: string = "error-test-2";
+      cy.ouiaId("create-smart-event-instance", "PF4/Button").click();
+      cy.ouiaId("create-instance", "PF4/ModalContent").then(($modal) => {
+        cy.wrap($modal)
+          .should("be.visible")
+          .within(() => {
+            cy.ouiaId("new-name", "PF4/TextInput").type(errorInstanceName);
+            cy.ouiaId("submit", "PF4/Button").click();
+            cy.ouiaId("error-instance-create-fail", "PF4/Alert").should(
+              "have.text",
+              "Danger alert:Error while creating a Smart Event instance. Please, try again later."
+            );
+          });
+      });
+    });
+
+    it("Submit and expect quota error", () => {
+      const errorInstanceName: string = "quota-error";
+      cy.ouiaId("create-smart-event-instance", "PF4/Button").click();
+      cy.ouiaId("create-instance", "PF4/ModalContent").then(($modal) => {
+          cy.wrap($modal)
+              .should("be.visible")
+              .within(() => {
+                  cy.ouiaId("new-name", "PF4/TextInput").type(errorInstanceName);
+                  cy.ouiaId("submit", "PF4/Button").click();
+                  cy.ouiaId("error-instance-create-fail", "PF4/Alert").should(
+                      "contain.text",
+                      "Warning alert:Your organization is out of quota."
+                  );
+              });
+      });
     });
   });
 

--- a/cypress/integration/instance/InstanceCreation.ts
+++ b/cypress/integration/instance/InstanceCreation.ts
@@ -137,16 +137,16 @@ describe("the 'Create a SE instance' Modal", () => {
       const errorInstanceName: string = "quota-error";
       cy.ouiaId("create-smart-event-instance", "PF4/Button").click();
       cy.ouiaId("create-instance", "PF4/ModalContent").then(($modal) => {
-          cy.wrap($modal)
-              .should("be.visible")
-              .within(() => {
-                  cy.ouiaId("new-name", "PF4/TextInput").type(errorInstanceName);
-                  cy.ouiaId("submit", "PF4/Button").click();
-                  cy.ouiaId("error-instance-create-fail", "PF4/Alert").should(
-                      "contain.text",
-                      "Warning alert:Your organization is out of quota."
-                  );
-              });
+        cy.wrap($modal)
+          .should("be.visible")
+          .within(() => {
+            cy.ouiaId("new-name", "PF4/TextInput").type(errorInstanceName);
+            cy.ouiaId("submit", "PF4/Button").click();
+            cy.ouiaId("error-instance-create-fail", "PF4/Alert").should(
+              "contain.text",
+              "Warning alert:Your organization is out of quota."
+            );
+          });
       });
     });
   });

--- a/mocked-api/handlers.ts
+++ b/mocked-api/handlers.ts
@@ -218,9 +218,10 @@ export const handlers = [
       );
     }
 
-    if (name == "error-test") {
+    if (name.includes("error-test")) {
       return res(
         ctx.status(500),
+        ctx.delay(apiDelay),
         ctx.json({
           kind: "ErrorsResponse",
           items: [

--- a/src/hooks/useBridgesApi/useCreateBridgeApi.ts
+++ b/src/hooks/useBridgesApi/useCreateBridgeApi.ts
@@ -43,7 +43,7 @@ export function useCreateBridgeApi(): {
               onError("quota-error");
               break;
             default:
-                onError("generic-error");
+              onError("generic-error");
           }
         } else {
           onError("generic-error");

--- a/src/hooks/useBridgesApi/useCreateBridgeApi.ts
+++ b/src/hooks/useBridgesApi/useCreateBridgeApi.ts
@@ -42,6 +42,8 @@ export function useCreateBridgeApi(): {
             case APIErrorCodes.ERROR_40:
               onError("quota-error");
               break;
+            default:
+                onError("generic-error");
           }
         } else {
           onError("generic-error");


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-1196

Steps to test:
- run the app against mocked APIs with `npm run start:mocked`
- click on `Create Smart Events Instance`
- enter a name containing `error-test`, like `bridge error-test`
- submit the form by clicking on `Create Smart Events Instance`
- after the API request is done, the dialog exits its loading status and the generic error alert appears on top