### PR TITLE
[no-jira] fix status popover test DOM instability

### DIFF
--- a/cypress/integration/instance/InstanceCreation.ts
+++ b/cypress/integration/instance/InstanceCreation.ts
@@ -62,6 +62,7 @@ describe("the 'Create a SE instance' Modal", () => {
         );
         progressStepsStatuses(SEInstanceStatus.ACCEPTED);
 
+        //The first steps takes about 65 secs.
         cy.ouiaId("steps-count", "QE/StackItem", { timeout: 90000 }).should(
           "have.text",
           "1 of 3 steps completed"
@@ -69,7 +70,9 @@ describe("the 'Create a SE instance' Modal", () => {
         progressStepsStatuses(SEInstanceStatus.PREPARING);
 
         if (isEnvironmentType(EnvType.Mocked)) {
-          cy.ouiaId("steps-count", "QE/StackItem", { timeout: 60000 }).should(
+          //Preparing -> Ready state takes 9 secs.
+          //The Popover disappears on Dev when we assert this element.
+          cy.ouiaId("steps-count", "QE/StackItem", { timeout: 10000 }).should(
             "have.text",
             "2 of 3 steps completed"
           );
@@ -93,7 +96,7 @@ describe("the 'Create a SE instance' Modal", () => {
       });
   });
 
-  it.skip("Submit and expect error", () => {
+  it("Submit and expect error", () => {
     const errorInstanceName: string = "error-test";
     cy.ouiaId("create-smart-event-instance", "PF4/Button").click();
     cy.ouiaId("create-instance", "PF4/ModalContent").then(($modal) => {
@@ -110,7 +113,7 @@ describe("the 'Create a SE instance' Modal", () => {
     });
   });
 
-  it.skip("Cancel", () => {
+  it("Cancel", () => {
     const canceledInstanceName: string = uniqueName("canceled-instance");
     createInstance(canceledInstanceName, "cancel");
 

--- a/cypress/integration/instance/InstanceCreation.ts
+++ b/cypress/integration/instance/InstanceCreation.ts
@@ -55,40 +55,26 @@ describe("the 'Create a SE instance' Modal", () => {
         cy.ouiaId("info-banner", "QE/StackItem")
           .ouiaId("ready-shortly", "PF4/Text")
           .should("be.visible");
+
         cy.ouiaId("steps-count", "QE/StackItem").should(
           "have.text",
           "0 of 3 steps completed"
         );
-
-        // Prepare cypress for 'non deterministic' updates in 'Status' popover
-        // The 'deterministic' updates would be: (0 of 3, 1 of 3, 2 of 3 and Done)
-        // However in reality it may happen: (0 of 3, 1 of 3 and Done) or (0 of 3, 2 of 3 and Done) or ...
-        // see https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__errors/cypress/e2e/test-fails.cy.js
-        cy.on("fail", (e, runnable) => {
-          console.error("error", e);
-          console.error("runnable", runnable);
-
-          if (
-            isEnvironmentType(EnvType.Dev) &&
-            e.name === "AssertionError" &&
-            e.message.includes("of 3 steps completed")
-          ) {
-            return true; //does not matter if true or false
-          }
-          throw e;
-        });
-
         progressStepsStatuses(SEInstanceStatus.ACCEPTED);
-        cy.ouiaId("steps-count", "QE/StackItem", { timeout: 120000 }).should(
+
+        cy.ouiaId("steps-count", "QE/StackItem", { timeout: 90000 }).should(
           "have.text",
           "1 of 3 steps completed"
         );
         progressStepsStatuses(SEInstanceStatus.PREPARING);
-        cy.ouiaId("steps-count", "QE/StackItem", { timeout: 120000 }).should(
-          "have.text",
-          "2 of 3 steps completed"
-        );
-        progressStepsStatuses(SEInstanceStatus.PROVISIONING);
+
+        if (isEnvironmentType(EnvType.Mocked)) {
+          cy.ouiaId("steps-count", "QE/StackItem", { timeout: 60000 }).should(
+            "have.text",
+            "2 of 3 steps completed"
+          );
+          progressStepsStatuses(SEInstanceStatus.PROVISIONING);
+        }
       });
     cy.ouiaId("se-status", "QE/Popover", { timeout: 60000 }).should(
       "not.exist"
@@ -107,7 +93,7 @@ describe("the 'Create a SE instance' Modal", () => {
       });
   });
 
-  it("Submit and expect error", () => {
+  it.skip("Submit and expect error", () => {
     const errorInstanceName: string = "error-test";
     cy.ouiaId("create-smart-event-instance", "PF4/Button").click();
     cy.ouiaId("create-instance", "PF4/ModalContent").then(($modal) => {
@@ -124,7 +110,7 @@ describe("the 'Create a SE instance' Modal", () => {
     });
   });
 
-  it("Cancel", () => {
+  it.skip("Cancel", () => {
     const canceledInstanceName: string = uniqueName("canceled-instance");
     createInstance(canceledInstanceName, "cancel");
 


### PR DESCRIPTION
The `Smart Events UI :: Dev :: Quality Checks` mostly ends with this error:
```
<![CDATA[ CypressError: Timed out retrying after 120000ms: `cy.should()` failed because this element is detached from the DOM. `<div data-ouia-component-id="steps-count" data-ouia-component-type="QE/StackItem" class="pf-l-stack__item">1 of 3 ...</div>` Cypress requires elements be attached in the DOM to interact with them. The previous command that ran was: > `cy.ouiaId()` This DOM element likely became detached somewhere between the previous and current command. Common situations why this happens: - Your JS framework re-rendered asynchronously - Your app code reacted to an event firing and removed the element You typically need to re-query for the element or add 'guards' which delay Cypress from running new commands.
https://on.cypress.io/element-has-detached-from-dom at $Cy.ensureAttached (https://prod.foo.redhat.com:1337/__cypress/runner/cypress_runner.js:147620:76) at applyChainers
...
From Your Spec Code: at Context.eval (webpack:///./integration/instance/InstanceCreation.ts:87:70) ]]>
```
By tracking the lifecycle of the creation of instances I found out that:
- Preparing -> Ready takes 9 secs
- UI update frequency is about 10 secs. 

It seems that we cannot assert all steps on real environment. The whole popover dialog disappears in the middle of waiting rutine which asserts text `2 of 3 steps completed`.

The previous solution #226 does not catch all exceptions and the code becomes too complicated.