### PR TITLE
NO-JIRA: Fix @xmldom/xmldom security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2759,14 +2759,14 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.5.tgz",
-      "integrity": "sha512-/uZkyPUZMRExZs+DZQVnc+uoDwLfs1gFNvcRY5S3Gu78U+uhovaSEUW3tuyld1e7Oke5Qphfseb8v66V+H1zWQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.6.tgz",
+      "integrity": "sha512-201pBIWehTURb6q8Gheu4Zhvd3Ox1U4BJq5KiOQsYzkWyfiOG4pwcz5hPZIEryztgrf8/sdwABpvY757xMmfrQ==",
       "dev": true,
       "dependencies": {
         "@open-draft/until": "^1.0.3",
         "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.7.5",
+        "@xmldom/xmldom": "^0.8.3",
         "debug": "^4.3.3",
         "headers-polyfill": "^3.1.0",
         "outvariant": "^1.2.1",
@@ -4845,9 +4845,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
-      "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.5.tgz",
+      "integrity": "sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -6040,7 +6040,7 @@
     "node_modules/charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -6638,7 +6638,7 @@
     "node_modules/crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -9989,9 +9989,9 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.0.tgz",
-      "integrity": "sha512-AVwgTAzeGpF7kwUCMc9HbAoCKFcHGEfmWkaI8g0jprrkh9VPRaofIsfV7Lw8UuR9pi4Rk7IIjJce8l0C+jSJNA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
+      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
       "dev": true
     },
     "node_modules/hoist-non-react-statics": {
@@ -16025,9 +16025,9 @@
       }
     },
     "node_modules/strict-event-emitter": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.7.tgz",
-      "integrity": "sha512-TavbHJ87WD2tDbKI7bTrmc6U4J4Qjh8E9fVvFkIFw2gCu34Wxstn2Yas0+4D78FJN8DOTEzxiT+udBdraRk4UQ==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
       "dev": true,
       "dependencies": {
         "events": "^3.3.0"
@@ -20284,14 +20284,14 @@
       }
     },
     "@mswjs/interceptors": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.5.tgz",
-      "integrity": "sha512-/uZkyPUZMRExZs+DZQVnc+uoDwLfs1gFNvcRY5S3Gu78U+uhovaSEUW3tuyld1e7Oke5Qphfseb8v66V+H1zWQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.6.tgz",
+      "integrity": "sha512-201pBIWehTURb6q8Gheu4Zhvd3Ox1U4BJq5KiOQsYzkWyfiOG4pwcz5hPZIEryztgrf8/sdwABpvY757xMmfrQ==",
       "dev": true,
       "requires": {
         "@open-draft/until": "^1.0.3",
         "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.7.5",
+        "@xmldom/xmldom": "^0.8.3",
         "debug": "^4.3.3",
         "headers-polyfill": "^3.1.0",
         "outvariant": "^1.2.1",
@@ -21977,9 +21977,9 @@
       "requires": {}
     },
     "@xmldom/xmldom": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
-      "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.5.tgz",
+      "integrity": "sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==",
       "dev": true
     },
     "@xstate/inspect": {
@@ -22854,7 +22854,7 @@
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "dev": true
     },
     "check-more-types": {
@@ -23291,7 +23291,7 @@
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "dev": true
     },
     "css-declaration-sorter": {
@@ -25777,9 +25777,9 @@
       "dev": true
     },
     "headers-polyfill": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.0.tgz",
-      "integrity": "sha512-AVwgTAzeGpF7kwUCMc9HbAoCKFcHGEfmWkaI8g0jprrkh9VPRaofIsfV7Lw8UuR9pi4Rk7IIjJce8l0C+jSJNA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
+      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
       "dev": true
     },
     "hoist-non-react-statics": {
@@ -30269,9 +30269,9 @@
       }
     },
     "strict-event-emitter": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.7.tgz",
-      "integrity": "sha512-TavbHJ87WD2tDbKI7bTrmc6U4J4Qjh8E9fVvFkIFw2gCu34Wxstn2Yas0+4D78FJN8DOTEzxiT+udBdraRk4UQ==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
       "dev": true,
       "requires": {
         "events": "^3.3.0"

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.47.0).
+ * Mock Service Worker (0.47.4).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.


### PR DESCRIPTION
See security alert: https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox-ui/security/dependabot/6

`@xmldom/xmldom` versions `< 0.7.7` have vulnerability issues. We already fixed this dep issues in the past with `npm audit fix`, moving from `0.7.5` to `0.7.6` (#238).
We would like to avoid doing this for each minor/patch release until we get a good one.

This is the xmldom dependency tree:
```
smartevents-ui@0.0.1 /home/remanuel/workspace/sandbox-ui
└─┬ msw@0.47.4
  └─┬ @mswjs/interceptors@0.17.5
    └── @xmldom/xmldom@0.7.6
```

Unfortunately there's no straightforward way to update xmldom by updating its parent deps. [`@mswjs/interceptors`](https://github.com/mswjs/interceptors/blob/aff787ee28e58737662b31b93e2b7f24faad7beb/package.json#L71) is listing it with `"@xmldom/xmldom": "^0.8.3"`, so our `0.7.6` version is satisfying the dep requirement, running `npm update msw` will do basically nothing.

The only option I had was to manually uninstall and reinstall `msw` to get the latest versions of all its transitive deps.

As a side note, this could be the same reason why renovate is not opening a PR for it. There's no way to fix this by just updating versions inside `package.json` given how the involved transitive deps are declared. (see [`transitiveRemediation` docs](https://docs.renovatebot.com/configuration-options/#transitiveremediation) about remediations not affecting `package.json`) 


 