### PR TITLE
MGDOBR-1203:Disable processor creation for FAILED SE instances

### DIFF
--- a/src/app/Instance/InstancePage/InstancePage.tsx
+++ b/src/app/Instance/InstancePage/InstancePage.tsx
@@ -295,6 +295,7 @@ const InstancePage = (): JSX.Element => {
               <ProcessorsTabContent
                 instanceId={instanceId}
                 pageTitle={getPageTitle(bridge)}
+                bridgeStatus={bridge?.status}
               />
             )}
           </TabContent>

--- a/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
+++ b/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
@@ -19,7 +19,7 @@ import {
   ManagedResourceStatus,
   ProcessorResponse,
 } from "@rhoas/smart-events-management-sdk";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { formatDistance } from "date-fns";
 import { useTranslation } from "@rhoas/app-services-ui-components";
 import { useGetProcessorsApi } from "../../../hooks/useProcessorsApi/useGetProcessorsApi";
@@ -42,6 +42,7 @@ export const ProcessorsTabContent = ({
   pageTitle,
   bridgeStatus,
 }: ProcessorTabContentProps): JSX.Element => {
+  const history = useHistory();
   const { t } = useTranslation(["smartEventsTempDictionary"]);
 
   const [currentPage, setCurrentPage] = useState<number>(FIRST_PAGE);
@@ -139,16 +140,17 @@ export const ProcessorsTabContent = ({
 
   const customToolbarElement = areProcessorsLoading ? (
     <Skeleton width={"170px"} height={"35px"} />
-  ) : bridgeStatus == ManagedResourceStatus.Failed ? (
-    <Button ouiaId="create-processor" variant="primary" isDisabled={true}>
+  ) : (
+    <Button
+      ouiaId="create-processor"
+      variant="primary"
+      isDisabled={bridgeStatus !== ManagedResourceStatus.Ready}
+      onClick={(): void =>
+        history.push(`/instance/${instanceId}/create-processor`)
+      }
+    >
       {t("processor.createProcessor")}
     </Button>
-  ) : (
-    <Link to={`/instance/${instanceId}/create-processor`}>
-      <Button ouiaId="create-processor" variant="primary">
-        {t("processor.createProcessor")}
-      </Button>
-    </Link>
   );
 
   const triggerGetProcessors = useCallback(

--- a/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
+++ b/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
@@ -8,6 +8,7 @@ import {
   EmptyState,
   EmptyStateIcon,
   PageSection,
+  Skeleton,
   Title,
 } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons";
@@ -33,11 +34,13 @@ import SEStatusLabel from "@app/components/SEStatusLabel/SEStatusLabel";
 interface ProcessorTabContentProps {
   instanceId: string;
   pageTitle: JSX.Element;
+  bridgeStatus: string | undefined;
 }
 
 export const ProcessorsTabContent = ({
   instanceId,
   pageTitle,
+  bridgeStatus,
 }: ProcessorTabContentProps): JSX.Element => {
   const { t } = useTranslation(["smartEventsTempDictionary"]);
 
@@ -105,14 +108,6 @@ export const ProcessorsTabContent = ({
     },
   ];
 
-  const customToolbarElement = (
-    <Link to={`/instance/${instanceId}/create-processor`}>
-      <Button ouiaId="create-processor" variant="primary">
-        {t("processor.createProcessor")}
-      </Button>
-    </Link>
-  );
-
   const deleteProcessor = (id: string, name: string): void => {
     setDeleteProcessorId(id);
     setDeleteProcessorName(name);
@@ -141,6 +136,20 @@ export const ProcessorsTabContent = ({
     isLoading: areProcessorsLoading,
     error: processorsError,
   } = useGetProcessorsApi();
+
+  const customToolbarElement = areProcessorsLoading ? (
+    <Skeleton width={"170px"} height={"35px"} />
+  ) : bridgeStatus == ManagedResourceStatus.Failed ? (
+    <Button ouiaId="create-processor" variant="primary" isDisabled={true}>
+      {t("processor.createProcessor")}
+    </Button>
+  ) : (
+    <Link to={`/instance/${instanceId}/create-processor`}>
+      <Button ouiaId="create-processor" variant="primary">
+        {t("processor.createProcessor")}
+      </Button>
+    </Link>
+  );
 
   const triggerGetProcessors = useCallback(
     (): void =>

--- a/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
+++ b/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
@@ -138,7 +138,7 @@ export const ProcessorsTabContent = ({
     error: processorsError,
   } = useGetProcessorsApi();
 
-  const customToolbarElement = areProcessorsLoading ? (
+  const customToolbarElement = !bridgeStatus ? (
     <Skeleton width={"170px"} height={"35px"} />
   ) : (
     <Button


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-1203

Steps to test it:

- Create a bridge instance with Incorrect parameters to enter into Failed state.
- Open the failed bridge instance detail page.
- Create processor button will be disabled for the failed bridge instance. 