### PR TITLE
MGDOBR-1229: Add support for filter in our overview pages

### DIFF
--- a/locales/en/smart-events.json
+++ b/locales/en/smart-events.json
@@ -41,8 +41,7 @@
       "ready": "Ready",
       "creating": "Creating",
       "deleting": "Deleting",
-      "failed": "Failed",
-      "preparing": "Preparing"
+      "failed": "Failed"
     },
     "resourceSteps": {
       "pending": {

--- a/locales/en/smart-events.json
+++ b/locales/en/smart-events.json
@@ -3,6 +3,7 @@
     "access": "Access",
     "actions": "Actions",
     "addressFormErrors": "Address form errors to proceed.",
+    "adjustYourFilters": "Adjust your filters and try again, or <0>clear all filters</0>.",
     "ago": "ago",
     "cancel": "Cancel",
     "close": "Close",
@@ -40,7 +41,8 @@
       "ready": "Ready",
       "creating": "Creating",
       "deleting": "Deleting",
-      "failed": "Failed"
+      "failed": "Failed",
+      "preparing": "Preparing"
     },
     "resourceSteps": {
       "pending": {

--- a/mocked-api/handlers.ts
+++ b/mocked-api/handlers.ts
@@ -108,11 +108,6 @@ export const handlers = [
     const status = req.url.searchParams.getAll("status");
 
     const bridgeQuery = {
-      take: size,
-      skip: page * size,
-      orderBy: {
-        submitted_at: "desc",
-      },
       where: {},
     } as QueryOptions & QuerySelector<Partial<BridgeResponse>>;
 
@@ -130,8 +125,17 @@ export const handlers = [
     }
 
     const items = db.bridge
-      .findMany(bridgeQuery)
+      .findMany({
+        take: size,
+        skip: page * size,
+        orderBy: {
+          submitted_at: "desc",
+        },
+        ...bridgeQuery,
+      })
       .map((item) => prepareBridge(item as unknown as Record<string, unknown>));
+
+    const count = db.bridge.count(bridgeQuery);
 
     return res(
       ctx.status(200),
@@ -141,7 +145,7 @@ export const handlers = [
         items,
         page,
         size: items.length,
-        total: db.bridge.count(),
+        total: count,
       })
     );
   }),

--- a/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
+++ b/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
@@ -138,14 +138,13 @@ export const ProcessorsTabContent = ({
   } = useGetProcessorsApi();
 
   const triggerGetProcessors = useCallback((): void => {
-    const nameParam = nameSearchParam ?? undefined;
-    getProcessors(instanceId, page, perPage, nameParam, statuses, true);
+    getProcessors(instanceId, nameSearchParam, page, perPage, statuses, true);
   }, [getProcessors, instanceId, nameSearchParam, page, perPage, statuses]);
 
   const handleOnDeleteProcessorSuccess = useCallback((): void => {
     setShowProcessorDeleteModal(false);
-    getProcessors(instanceId, page, perPage);
-  }, [getProcessors, instanceId, page, perPage]);
+    getProcessors(instanceId, nameSearchParam, page, perPage, statuses);
+  }, [getProcessors, instanceId, nameSearchParam, page, perPage, statuses]);
 
   const rowOuiaId = useCallback(
     ({ row, rowIndex }): string =>
@@ -169,8 +168,7 @@ export const ProcessorsTabContent = ({
   usePolling(() => triggerGetProcessors(), 10000);
 
   useEffect(() => {
-    const nameParam = nameSearchParam ?? undefined;
-    getProcessors(instanceId, page, perPage, nameParam, statuses);
+    getProcessors(instanceId, nameSearchParam, page, perPage, statuses);
   }, [getProcessors, instanceId, nameSearchParam, page, perPage, statuses]);
 
   useEffect(() => {

--- a/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
+++ b/src/app/Instance/InstancePage/ProcessorsTabContent.tsx
@@ -42,7 +42,7 @@ export const ProcessorsTabContent = ({
       nameSearchParam,
       statuses,
     },
-  } = useTablePageParams();
+  } = useTablePageParams({ hasNameFilter: true, hasStatusesFilter: true });
 
   const [totalRows, setTotalRows] = useState<number>();
   const [deleteProcessorId, setDeleteProcessorId] = useState("");
@@ -229,7 +229,7 @@ export const ProcessorsTabContent = ({
           itemCount={totalRows}
           isFiltered={
             (nameSearchParam && nameSearchParam.length > 0) ||
-            statuses.length > 0
+            (statuses && statuses.length > 0)
           }
           onClearAllFilters={onClearAllFilters}
           onPageChange={setPagination}

--- a/src/app/Instance/InstancesListPage/InstancesListPage.tsx
+++ b/src/app/Instance/InstancesListPage/InstancesListPage.tsx
@@ -43,7 +43,7 @@ const InstancesListPage = (): JSX.Element => {
       nameSearchParam,
       statuses,
     },
-  } = useTablePageParams();
+  } = useTablePageParams({ hasNameFilter: true, hasStatusesFilter: true });
 
   const [totalRows, setTotalRows] = useState<number>();
   const [showInstanceDrawer, setShowInstanceDrawer] = useState<boolean>(false);
@@ -280,7 +280,7 @@ const InstancesListPage = (): JSX.Element => {
           itemCount={totalRows}
           isFiltered={
             (nameSearchParam && nameSearchParam.length > 0) ||
-            statuses.length > 0
+            (statuses && statuses.length > 0)
           }
           onClearAllFilters={onClearAllFilters}
           onPageChange={setPagination}

--- a/src/app/Instance/InstancesListPage/InstancesListPage.tsx
+++ b/src/app/Instance/InstancesListPage/InstancesListPage.tsx
@@ -114,15 +114,13 @@ const InstancesListPage = (): JSX.Element => {
   const { bridgeListResponse, getBridges, error } = useGetBridgesApi();
 
   const triggerGetBridges = useCallback((): void => {
-    const nameParam = nameSearchParam ?? undefined;
-    getBridges(page, perPage, nameParam, statuses, true);
+    getBridges(nameSearchParam, page, perPage, statuses, true);
   }, [getBridges, page, perPage, statuses, nameSearchParam]);
 
   usePolling(() => triggerGetBridges(), 10000);
 
   useEffect(() => {
-    const nameParam = nameSearchParam ?? undefined;
-    getBridges(page, perPage, nameParam, statuses);
+    getBridges(nameSearchParam, page, perPage, statuses);
   }, [getBridges, page, perPage, statuses, nameSearchParam]);
 
   useEffect(() => {
@@ -154,8 +152,8 @@ const InstancesListPage = (): JSX.Element => {
 
   const onCreateBridge = useCallback(() => {
     setShowCreateInstance(false);
-    getBridges(page, perPage);
-  }, [getBridges, page, perPage]);
+    getBridges(nameSearchParam, page, perPage, statuses);
+  }, [getBridges, nameSearchParam, page, perPage, statuses]);
 
   const handleCreate = useCallback<CreateInstanceProps["createBridge"]>(
     function (data, onSuccess, onError) {
@@ -185,9 +183,16 @@ const InstancesListPage = (): JSX.Element => {
 
   const handleOnDeleteSuccess = useCallback((): void => {
     setShowDeleteModal(false);
-    getBridges(page, perPage);
+    getBridges(nameSearchParam, page, perPage, statuses);
     resetDeleteInstance();
-  }, [getBridges, page, perPage, resetDeleteInstance]);
+  }, [
+    getBridges,
+    nameSearchParam,
+    page,
+    perPage,
+    resetDeleteInstance,
+    statuses,
+  ]);
 
   const handleOnDeleteCancel = useCallback((): void => {
     setShowDeleteModal(false);

--- a/src/app/components/EmptyState/EmptyStateNoData.tsx
+++ b/src/app/components/EmptyState/EmptyStateNoData.tsx
@@ -10,7 +10,7 @@ import {
 import { PlusCircleIcon } from "@patternfly/react-icons";
 import { Trans } from "@rhoas/app-services-ui-components";
 
-interface EmptyStateProps {
+interface EmptyStateNoDataProps {
   createButton: {
     title: string;
     onCreate: () => void;
@@ -23,11 +23,11 @@ interface EmptyStateProps {
   title: string;
 }
 
-export const EmptyState = ({
+export const EmptyStateNoData = ({
   createButton,
   quickStartGuide,
   title,
-}: EmptyStateProps): JSX.Element => {
+}: EmptyStateNoDataProps): JSX.Element => {
   return (
     <EmptyStatePF variant={EmptyStateVariant.small}>
       <EmptyStateIcon icon={PlusCircleIcon} />

--- a/src/app/components/EmptyState/EmptyStateNoResults.tsx
+++ b/src/app/components/EmptyState/EmptyStateNoResults.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import {
+  EmptyState as EmptyStatePF,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+} from "@patternfly/react-core";
+import { SearchIcon } from "@patternfly/react-icons";
+import { Trans } from "@rhoas/app-services-ui-components";
+
+interface EmptyStateNoResultsProps {
+  bodyMsgI18nKey: string;
+  onClearAllFilters: () => void;
+  title: string;
+}
+
+export const EmptyStateNoResults = ({
+  bodyMsgI18nKey,
+  onClearAllFilters,
+  title,
+}: EmptyStateNoResultsProps): JSX.Element => {
+  return (
+    <EmptyStatePF variant={EmptyStateVariant.small}>
+      <EmptyStateIcon icon={SearchIcon} />
+      <Title headingLevel="h2" size="lg">
+        {title}
+      </Title>
+      <EmptyStateBody>
+        <Trans
+          ns={"smartEventsTempDictionary"}
+          i18nKey={bodyMsgI18nKey}
+          components={[
+            <a key="on-clear-filters" onClick={onClearAllFilters} />,
+          ]}
+        />
+      </EmptyStateBody>
+    </EmptyStatePF>
+  );
+};

--- a/src/hooks/useBridgesApi/useGetBridgesApi.ts
+++ b/src/hooks/useBridgesApi/useGetBridgesApi.ts
@@ -9,7 +9,13 @@ import axios, { CancelTokenSource } from "axios";
 import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useGetBridgesApi(): {
-  getBridges: (pageReq?: number, sizeReq?: number, isPolling?: boolean) => void;
+  getBridges: (
+    pageReq?: number,
+    sizeReq?: number,
+    nameReq?: string,
+    statusesReq?: ManagedResourceStatus[],
+    isPolling?: boolean
+  ) => void;
   bridgeListResponse?: BridgeListResponse;
   error: unknown;
 } {
@@ -20,7 +26,13 @@ export function useGetBridgesApi(): {
   const { getToken, apiBaseUrl } = useSmartEvents();
 
   const getBridges = useCallback(
-    (pageReq?: number, sizeReq?: number, isPolling = false): void => {
+    (
+      pageReq?: number,
+      sizeReq?: number,
+      nameReq?: string,
+      statusesReq?: ManagedResourceStatus[],
+      isPolling = false
+    ): void => {
       if (!isPolling) {
         setBridgeListResponse(undefined);
       }
@@ -42,10 +54,10 @@ export function useGetBridgesApi(): {
 
       bridgeApi
         .getBridges(
-          undefined,
+          nameReq,
           pageNumber,
           sizeReq,
-          new Set<ManagedResourceStatus>(),
+          new Set<ManagedResourceStatus>(statusesReq),
           {
             cancelToken: source.token,
           }

--- a/src/hooks/useBridgesApi/useGetBridgesApi.ts
+++ b/src/hooks/useBridgesApi/useGetBridgesApi.ts
@@ -7,6 +7,7 @@ import {
 import { useCallback, useRef, useState } from "react";
 import axios, { CancelTokenSource } from "axios";
 import { useSmartEvents } from "@contexts/SmartEventsContext";
+import { getUserFacingStatuses, ResourceStatus } from "@utils/statusUtils";
 
 export function useGetBridgesApi(): {
   getBridges: (
@@ -57,7 +58,7 @@ export function useGetBridgesApi(): {
           nameReq ?? undefined,
           pageNumber,
           sizeReq,
-          new Set<ManagedResourceStatus>(statusesReq),
+          getUserFacingStatuses(statusesReq as ResourceStatus[]),
           {
             cancelToken: source.token,
           }

--- a/src/hooks/useBridgesApi/useGetBridgesApi.ts
+++ b/src/hooks/useBridgesApi/useGetBridgesApi.ts
@@ -10,9 +10,9 @@ import { useSmartEvents } from "@contexts/SmartEventsContext";
 
 export function useGetBridgesApi(): {
   getBridges: (
+    nameReq: string | null,
     pageReq?: number,
     sizeReq?: number,
-    nameReq?: string,
     statusesReq?: ManagedResourceStatus[],
     isPolling?: boolean
   ) => void;
@@ -27,9 +27,9 @@ export function useGetBridgesApi(): {
 
   const getBridges = useCallback(
     (
+      nameReq: string | null,
       pageReq?: number,
       sizeReq?: number,
-      nameReq?: string,
       statusesReq?: ManagedResourceStatus[],
       isPolling = false
     ): void => {
@@ -54,7 +54,7 @@ export function useGetBridgesApi(): {
 
       bridgeApi
         .getBridges(
-          nameReq,
+          nameReq ?? undefined,
           pageNumber,
           sizeReq,
           new Set<ManagedResourceStatus>(statusesReq),

--- a/src/hooks/useProcessorsApi/useGetProcessorsApi.ts
+++ b/src/hooks/useProcessorsApi/useGetProcessorsApi.ts
@@ -13,6 +13,8 @@ export function useGetProcessorsApi(): {
     bridgeId: string,
     pageReq?: number,
     sizeReq?: number,
+    nameReq?: string,
+    statusesReq?: ManagedResourceStatus[],
     isPolling?: boolean
   ) => void;
   processorListResponse?: ProcessorListResponse;
@@ -29,6 +31,8 @@ export function useGetProcessorsApi(): {
       bridgeId: string,
       pageReq?: number,
       sizeReq?: number,
+      nameReq?: string,
+      statusesReq?: ManagedResourceStatus[],
       isPolling?: boolean
     ): void => {
       if (!isPolling) {
@@ -53,10 +57,10 @@ export function useGetProcessorsApi(): {
       processorsApi
         .getProcessors(
           bridgeId,
-          undefined,
+          nameReq,
           pageNumber,
           sizeReq,
-          new Set<ManagedResourceStatus>(),
+          new Set<ManagedResourceStatus>(statusesReq),
           {
             cancelToken: source.token,
           }

--- a/src/hooks/useProcessorsApi/useGetProcessorsApi.ts
+++ b/src/hooks/useProcessorsApi/useGetProcessorsApi.ts
@@ -11,9 +11,9 @@ import { useSmartEvents } from "@contexts/SmartEventsContext";
 export function useGetProcessorsApi(): {
   getProcessors: (
     bridgeId: string,
+    nameReq: string | null,
     pageReq?: number,
     sizeReq?: number,
-    nameReq?: string,
     statusesReq?: ManagedResourceStatus[],
     isPolling?: boolean
   ) => void;
@@ -29,9 +29,9 @@ export function useGetProcessorsApi(): {
   const getProcessors = useCallback(
     (
       bridgeId: string,
+      nameReq: string | null,
       pageReq?: number,
       sizeReq?: number,
-      nameReq?: string,
       statusesReq?: ManagedResourceStatus[],
       isPolling?: boolean
     ): void => {
@@ -57,7 +57,7 @@ export function useGetProcessorsApi(): {
       processorsApi
         .getProcessors(
           bridgeId,
-          nameReq,
+          nameReq ?? undefined,
           pageNumber,
           sizeReq,
           new Set<ManagedResourceStatus>(statusesReq),

--- a/src/hooks/useProcessorsApi/useGetProcessorsApi.ts
+++ b/src/hooks/useProcessorsApi/useGetProcessorsApi.ts
@@ -7,6 +7,7 @@ import {
 import { useCallback, useRef, useState } from "react";
 import axios, { CancelTokenSource } from "axios";
 import { useSmartEvents } from "@contexts/SmartEventsContext";
+import { getUserFacingStatuses, ResourceStatus } from "@utils/statusUtils";
 
 export function useGetProcessorsApi(): {
   getProcessors: (
@@ -60,7 +61,7 @@ export function useGetProcessorsApi(): {
           nameReq ?? undefined,
           pageNumber,
           sizeReq,
-          new Set<ManagedResourceStatus>(statusesReq),
+          getUserFacingStatuses(statusesReq as ResourceStatus[]),
           {
             cancelToken: source.token,
           }

--- a/src/hooks/useTablePageParams/useTablePageParams.ts
+++ b/src/hooks/useTablePageParams/useTablePageParams.ts
@@ -7,6 +7,7 @@ import {
 } from "@rhoas/app-services-ui-components";
 import { ManagedResourceStatus } from "@rhoas/smart-events-management-sdk";
 import { useCallback } from "react";
+import { CREATING_STATUS } from "@utils/statusUtils";
 
 /**
  * Custom hook useful for managing page parameters in pages where we have overview tables
@@ -87,9 +88,9 @@ export function useTablePageParams(): {
           chips: statusesChips.chips,
           options: {
             [ManagedResourceStatus.Ready]: t("common.statuses.ready"),
-            [ManagedResourceStatus.Preparing]: t("common.statuses.preparing"),
-            [ManagedResourceStatus.Deleting]: t("common.statuses.deleting"),
+            [CREATING_STATUS]: t("common.statuses.creating"),
             [ManagedResourceStatus.Failed]: t("common.statuses.failed"),
+            [ManagedResourceStatus.Deleting]: t("common.statuses.deleting"),
           },
           onToggle: statusesChips.toggle,
           onRemoveChip: statusesChips.remove,

--- a/src/hooks/useTablePageParams/useTablePageParams.ts
+++ b/src/hooks/useTablePageParams/useTablePageParams.ts
@@ -1,0 +1,104 @@
+import {
+  FilterType,
+  usePaginationSearchParams,
+  useTranslation,
+  useURLSearchParams,
+  useURLSearchParamsChips,
+} from "@rhoas/app-services-ui-components";
+import { ManagedResourceStatus } from "@rhoas/smart-events-management-sdk";
+import { useCallback } from "react";
+
+/**
+ * Custom hook useful for managing page parameters in pages where we have overview tables
+ * Managed page parameters are: pagination and filters (resource's name and status)
+ */
+export function useTablePageParams(): {
+  pagination: {
+    page: number;
+    perPage: number;
+    setPagination: (page: number, perPage: number) => void;
+  };
+  filters: {
+    filtersConfig: { [p: string]: FilterType };
+    onClearAllFilters: () => void;
+    nameSearchParam: string | null;
+    statuses: ManagedResourceStatus[];
+  };
+} {
+  const { t } = useTranslation(["smartEventsTempDictionary"]);
+
+  const { page, perPage, setPagination, setPaginationQuery } =
+    usePaginationSearchParams();
+
+  const { query: querySearchParams, update: updateSearchParams } =
+    useURLSearchParams();
+
+  const resetPaginationQuery = useCallback(
+    () => setPaginationQuery(1, perPage),
+    [perPage, setPaginationQuery]
+  );
+
+  const statusesChips = useURLSearchParamsChips<ManagedResourceStatus>(
+    "status",
+    resetPaginationQuery
+  );
+
+  const nameSearchParam = querySearchParams.get("name");
+
+  const onClearAllFilters = useCallback(() => {
+    const urlSearchParams = statusesChips.clearChained(
+      setPaginationQuery(1, perPage)
+    );
+    urlSearchParams.delete("name");
+    updateSearchParams(urlSearchParams);
+  }, [perPage, setPaginationQuery, statusesChips, updateSearchParams]);
+
+  const onClearNameFilter = (): void => {
+    const urlQueryParams = setPaginationQuery(1, perPage);
+    urlQueryParams.delete("name");
+    updateSearchParams(urlQueryParams);
+  };
+
+  const onNameSearch = (name: string): void => {
+    const urlQueryParams = setPaginationQuery(1, perPage);
+    urlQueryParams.set("name", name);
+    updateSearchParams(urlQueryParams);
+  };
+
+  return {
+    pagination: {
+      page,
+      perPage,
+      setPagination,
+    },
+    filters: {
+      filtersConfig: {
+        [t("common.name")]: {
+          type: "search",
+          chips: nameSearchParam ? [nameSearchParam] : [],
+          onSearch: onNameSearch,
+          onRemoveChip: onClearNameFilter,
+          onRemoveGroup: onClearNameFilter,
+          validate: () => true,
+          errorMessage: "",
+        },
+        [t("common.status")]: {
+          type: "checkbox",
+          chips: statusesChips.chips,
+          options: {
+            [ManagedResourceStatus.Ready]: t("common.statuses.ready"),
+            [ManagedResourceStatus.Preparing]: t("common.statuses.preparing"),
+            [ManagedResourceStatus.Deleting]: t("common.statuses.deleting"),
+            [ManagedResourceStatus.Failed]: t("common.statuses.failed"),
+          },
+          onToggle: statusesChips.toggle,
+          onRemoveChip: statusesChips.remove,
+          onRemoveGroup: statusesChips.clear,
+        },
+      },
+      onClearAllFilters,
+      nameSearchParam,
+      statuses: statusesChips.chips,
+    },
+  };
+}

--- a/src/utils/statusUtils.ts
+++ b/src/utils/statusUtils.ts
@@ -1,0 +1,20 @@
+import { ManagedResourceStatus } from "@rhoas/smart-events-management-sdk";
+
+export type ResourceStatus = ManagedResourceStatus & "creating";
+
+export const CREATING_STATUS = "creating";
+
+export function getUserFacingStatuses(
+  statusesReq?: ResourceStatus[]
+): Set<ManagedResourceStatus> | undefined {
+  return statusesReq?.reduce((set, status) => {
+    if (status === CREATING_STATUS) {
+      set.add(ManagedResourceStatus.Accepted);
+      set.add(ManagedResourceStatus.Preparing);
+      set.add(ManagedResourceStatus.Provisioning);
+    } else {
+      set.add(status);
+    }
+    return set;
+  }, new Set<ManagedResourceStatus>());
+}


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/MGDOBR-1229

![image](https://user-images.githubusercontent.com/22591802/207924429-504f6206-e041-429a-a8ab-66a4e39ce9dd.png)

A few points:

1. Query params are preserved when going back with the browser's button but not when clicking on a link in the application. What should we do about it? What is the expected user experience?
2. I created a hook for managing page parameters for pages using table overviews to favor reusability. We can make this hook configurable (for instance, I may want to add the `name` filter and not `status`). Just let me know.
3. I just added a few statuses supported by the API. Should we add all of them? Support any other not in the current list?
![image](https://user-images.githubusercontent.com/22591802/207925011-1b1f2a93-01b3-4d73-941d-d8633553b80c.png)
4. It seems we have a defect (in `app-services-ui-component`) related to multiple chips when removing one of them:
![multiple_chips_filter_defect](https://user-images.githubusercontent.com/22591802/207925299-d4a1939d-f145-48f3-a360-ba8c5876830a.gif)
