### PR TITLE
NO JIRA: fix instabilities

### DIFF
--- a/cypress/integration/instance/InstanceCreation.ts
+++ b/cypress/integration/instance/InstanceCreation.ts
@@ -70,14 +70,8 @@ describe("the 'Create a SE instance' Modal", () => {
           "0 of 3 steps completed"
         );
         progressStepsStatuses(SEInstanceStatus.ACCEPTED);
-
-        //The first steps takes about 65 secs.
-        cy.ouiaId("steps-count", "QE/StackItem", { timeout: 90000 }).should(
-          "have.text",
-          "1 of 3 steps completed"
-        );
-        progressStepsStatuses(SEInstanceStatus.PREPARING);
       });
+    //Assertion of the other steps is not reliable enough. The UI updates the page every 10 seconds and it hides some states.
     cy.ouiaId("se-status", "QE/Popover", { timeout: 60000 }).should(
       "not.exist"
     );

--- a/cypress/integration/instance/InstanceStatuses.ts
+++ b/cypress/integration/instance/InstanceStatuses.ts
@@ -25,6 +25,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
       const instanceName: string = "Instance three";
       cy.ouiaId("Instances list table", "PF4/Table")
         .ouiaId(instanceName, "PF4/TableRow")
+        .scrollIntoView()
         .should("be.visible")
         .within(() => {
           //the name does not contain a link at the detail page
@@ -73,6 +74,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
       const instanceName: string = "Instance eight";
       cy.ouiaId("Instances list table", "PF4/Table")
         .ouiaId(instanceName, "PF4/TableRow")
+        .scrollIntoView()
         .should("be.visible")
         .within(() => {
           //the name does not contain a link at the detail page
@@ -122,6 +124,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
       const instanceName: string = "Instance four";
       cy.ouiaId("Instances list table", "PF4/Table")
         .ouiaId(instanceName, "PF4/TableRow")
+        .scrollIntoView()
         .should("be.visible")
         .within(() => {
           //the name does not contain a link at the detail page
@@ -171,6 +174,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
       const instanceName: string = "Instance two";
       cy.ouiaId("Instances list table", "PF4/Table")
         .ouiaId(instanceName, "PF4/TableRow")
+        .scrollIntoView()
         .should("be.visible")
         .within(() => {
           cy.get("td:first")
@@ -203,6 +207,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
       const instanceName: string = "Instance three";
       cy.ouiaId("Instances list table", "PF4/Table")
         .ouiaId(instanceName, "PF4/TableRow")
+        .scrollIntoView()
         .should("be.visible")
         .within(() => {
           cy.get("td:first").should("have.html", instanceName);

--- a/cypress/integration/instance/Pagination.ts
+++ b/cypress/integration/instance/Pagination.ts
@@ -95,7 +95,6 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
           const instanceTen = "Instance ten";
           let initialInstanceCount = parseInt(count.text());
           deleteInstance(instanceTen);
-          waitTillInstanceIsReady(instanceTen);
           deletedInstanceNotExist(instanceTen);
           cy.get(".pf-c-pagination__total-items >b:nth-of-type(2)").then(
             (count) => {

--- a/cypress/integration/instance/Pagination.ts
+++ b/cypress/integration/instance/Pagination.ts
@@ -90,19 +90,23 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
     });
 
     it("Page size after deleting an Instance ", () => {
+      const instanceTen = "Instance ten";
+      let initialInstanceCount = 0;
       cy.get(".pf-c-pagination__total-items >b:nth-of-type(2)").then(
         (count) => {
-          const instanceTen = "Instance ten";
-          let initialInstanceCount = parseInt(count.text());
-          deleteInstance(instanceTen);
-          deletedInstanceNotExist(instanceTen);
-          cy.get(".pf-c-pagination__total-items >b:nth-of-type(2)").then(
-            (count) => {
-              let instanceCountAfterDelete = parseInt(count.text());
-              expect(instanceCountAfterDelete).to.be.equal(
-                initialInstanceCount - 1
-              );
-            }
+          initialInstanceCount = parseInt(count.text());
+        }
+      );
+      deleteInstance(instanceTen);
+      //After the modal confirmed that the page is loading again and contains just the skeleton table.
+      //Instance one is mocked to be ready.
+      waitTillInstanceIsReady("Instance one");
+      deletedInstanceNotExist(instanceTen);
+      cy.get(".pf-c-pagination__total-items >b:nth-of-type(2)").then(
+        (count) => {
+          let instanceCountAfterDelete = parseInt(count.text());
+          expect(instanceCountAfterDelete).to.be.equal(
+            initialInstanceCount - 1
           );
         }
       );


### PR DESCRIPTION
This PR should fix several instabilities in the `Smart Events UI :: Mocked :: Quality Checks`.

- **when a bridge instance is created I have remove the dynamic assertion of the SE Status Popover dialog** (accepted -> preparing -> provisioning -> ready). The main problem is that update frequency of UI might hide some statuses like accepted -> provisioning -> ready or accepted -> preparing -> ready.
- **the InstanceStatuses test requires scrolling** to the desired bridge instance.
- **the Pagination test needs the waiting rutine** because the deletion of the bridge instance updates the Instances Page and shows skeletons. Previously the test was waiting on `instance ten` which was in state deleting (not ready). I have changed it to `instance one` because it is not affected by this test. 
