### PR TITLE
NO-JIRA: Fix Trans component usage 

### DIFF
--- a/src/app/components/EmptyState/EmptyStateNoData.tsx
+++ b/src/app/components/EmptyState/EmptyStateNoData.tsx
@@ -8,7 +8,7 @@ import {
   Title,
 } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons";
-import { Trans } from "@rhoas/app-services-ui-components";
+import { Trans, useTranslation } from "@rhoas/app-services-ui-components";
 
 export interface EmptyStateNoDataProps {
   createButton: {
@@ -28,6 +28,8 @@ export const EmptyStateNoData = ({
   quickStartGuide,
   title,
 }: EmptyStateNoDataProps): JSX.Element => {
+  const { t } = useTranslation("smartEventsTempDictionary");
+
   return (
     <EmptyStatePF variant={EmptyStateVariant.small}>
       <EmptyStateIcon icon={PlusCircleIcon} />
@@ -37,7 +39,7 @@ export const EmptyStateNoData = ({
       {quickStartGuide && (
         <EmptyStateBody>
           <Trans
-            ns={"smartEventsTempDictionary"}
+            t={t}
             i18nKey={quickStartGuide.i18nKey}
             components={[
               <a

--- a/src/app/components/EmptyState/EmptyStateNoResults.tsx
+++ b/src/app/components/EmptyState/EmptyStateNoResults.tsx
@@ -7,7 +7,7 @@ import {
   Title,
 } from "@patternfly/react-core";
 import { SearchIcon } from "@patternfly/react-icons";
-import { Trans } from "@rhoas/app-services-ui-components";
+import { Trans, useTranslation } from "@rhoas/app-services-ui-components";
 
 export interface EmptyStateNoResultsProps {
   bodyMsgI18nKey: string;
@@ -20,6 +20,8 @@ export const EmptyStateNoResults = ({
   onClearAllFilters,
   title,
 }: EmptyStateNoResultsProps): JSX.Element => {
+  const { t } = useTranslation("smartEventsTempDictionary");
+
   return (
     <EmptyStatePF variant={EmptyStateVariant.small}>
       <EmptyStateIcon icon={SearchIcon} />
@@ -28,7 +30,7 @@ export const EmptyStateNoResults = ({
       </Title>
       <EmptyStateBody>
         <Trans
-          ns={"smartEventsTempDictionary"}
+          t={t}
           i18nKey={bodyMsgI18nKey}
           components={[
             <a key="on-clear-filters" onClick={onClearAllFilters} />,


### PR DESCRIPTION
`EmptyState` stories inside storybook have some missing translations.
According to `react-i18next` [docs](https://react.i18next.com/latest/trans-component), the `Trans` component does not re-render when the dictionary is loaded/changed. This is an issue when running components in isolation without any `useTranslation` usage triggering re-renders.

It should be fixed now.
