### PR TITLE
MGDOBR-1339: "Create processor" header component poc

### DIFF
--- a/locales/en/smart-events.json
+++ b/locales/en/smart-events.json
@@ -109,10 +109,13 @@
     "quotaExceededErrorDescription": "To deploy a new instance, delete an existing one first."
   },
   "processor": {
+    "cancelEdits": "Cancel edits",
     "createProcessor": "Create processor",
     "creatingProcessor": "Creating processor",
     "delete": "Delete processor",
     "deleteProcessor": "Delete Processor?",
+    "deployProcessor": "Deploy Processor",
+    "editName": "Edit name",
     "errors": {
       "cantCreateProcessor": "Error while creating a Processor",
       "cantCreateProcessorBecauseInstanceNotAvailable": "The Smart Events instance you are associating it with is in the deletion phase or does not exist anymore.",
@@ -134,10 +137,12 @@
     "loadingProcessor": "Loading processor",
     "noProcessors": "No processors for this Smart Event instance",
     "notFound": "Processor not found",
+    "pleaseEnterAProcessorName": "Please enter a processor name",
     "processorName": "Processor name",
     "processorsListTable": "Processors list table",
-    "processorYAMLGuide": "Processor YAML Guide",
     "processorWillBeAvailableShortly": "Your Processor will be ready for use shortly after creation.",
+    "processorYAMLGuide": "Processor YAML Guide",
+    "setName": "Set name",
     "templateSelection": "Select processor template",
     "templateSelectionDescription": "Select a template to use as a basis for your processor YAML."
   }

--- a/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.css
+++ b/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.css
@@ -1,0 +1,3 @@
+.processor-name-input {
+  max-width: 400px;
+}

--- a/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.stories.tsx
+++ b/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.stories.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ProcessorEditHeader from "@app/components/POCs/ProcessorEditHeader/ProcessorEditHeader";
+
+export default {
+  title: "PoCs/Processor Edit Header",
+  component: ProcessorEditHeader,
+  args: {
+    onCreate: () => {},
+    showCreateAction: true,
+  },
+} as ComponentMeta<typeof ProcessorEditHeader>;
+
+const Template: ComponentStory<typeof ProcessorEditHeader> = (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { onNameChange, name, ...rest } = args;
+  const [value, setValue] = useState(args.name);
+
+  return (
+    <div style={{ padding: "3em 0" }}>
+      <ProcessorEditHeader
+        onNameChange={(newValue): void => setValue(newValue)}
+        name={value}
+        {...rest}
+      />
+    </div>
+  );
+};
+
+export const ActionVisible = Template.bind({});
+ActionVisible.args = {};
+
+export const ActionHidden = Template.bind({});
+ActionHidden.args = {
+  showCreateAction: false,
+};
+
+export const ExistingProcessorName = Template.bind({});
+ExistingProcessorName.args = {
+  name: "My Slack Processor",
+};

--- a/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.tsx
+++ b/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.tsx
@@ -95,7 +95,6 @@ const ProcessorEditHeader: FunctionComponent<ProcessorEditHeaderProps> = (
                       helperTextInvalidIcon={<ExclamationCircleIcon />}
                     >
                       <TextInput
-                        className="pf-c-form-control"
                         id={"processor-name"}
                         value={nameValue}
                         type="text"
@@ -111,7 +110,7 @@ const ProcessorEditHeader: FunctionComponent<ProcessorEditHeaderProps> = (
                   </Form>
                 </div>
                 <div className="pf-c-inline-edit__group pf-m-action-group pf-m-icon-group">
-                  <div className="pf-c-inline-edit__action pf-m-valid">
+                  <div className="pf-c-inline-edit__action">
                     <Button
                       variant={"plain"}
                       onClick={onDoneEditing}

--- a/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.tsx
+++ b/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.tsx
@@ -1,0 +1,163 @@
+import React, { FunctionComponent, useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  Form,
+  FormGroup,
+  FormProps,
+  PageSection,
+  PageSectionVariants,
+  Split,
+  SplitItem,
+  Text,
+  TextContent,
+  TextInput,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+import { useTranslation } from "@rhoas/app-services-ui-components";
+import {
+  CheckIcon,
+  ExclamationCircleIcon,
+  PencilAltIcon,
+  TimesIcon,
+} from "@patternfly/react-icons";
+
+export interface ProcessorEditHeaderProps {
+  name?: string;
+  onNameChange: (name: string) => void;
+  showCreateAction: boolean;
+  onCreate: () => void;
+}
+
+const ProcessorEditHeader: FunctionComponent<ProcessorEditHeaderProps> = (
+  props
+) => {
+  const { t } = useTranslation("smartEventsTempDictionary");
+  const {
+    name = t("processor.processorName") ?? "Processor name",
+    onNameChange,
+    onCreate,
+    showCreateAction,
+  } = props;
+  const [isEditing, setIsEditing] = useState(false);
+  const [nameValue, setNameValue] = useState(name);
+
+  const onStartEditing = (): void => {
+    setIsEditing(true);
+  };
+
+  const onDoneEditing = (): void => {
+    setIsEditing(false);
+    onNameChange(nameValue.trim());
+  };
+
+  const onCancelEditing = (): void => {
+    setIsEditing(false);
+    setNameValue(name);
+  };
+
+  const onChangeInputValue = (value: string): void => {
+    setNameValue(value);
+  };
+
+  const onFormSubmit: FormProps["onSubmit"] = (event): void => {
+    event.preventDefault();
+    if (isNameValid) {
+      onDoneEditing();
+    }
+  };
+
+  const isNameValid = useMemo(() => nameValue.trim().length > 0, [nameValue]);
+
+  useEffect(() => {
+    setNameValue(name);
+  }, [name]);
+
+  return (
+    <PageSection variant={PageSectionVariants.light} hasShadowBottom={true}>
+      <Split hasGutter={true}>
+        <SplitItem isFilled={true}>
+          {isEditing ? (
+            <div className="pf-c-inline-edit pf-m-inline-editable">
+              <div className="pf-c-inline-edit__group">
+                <div
+                  className="pf-c-inline-edit__input"
+                  style={{ maxWidth: 400 }}
+                >
+                  <Form id={"processor-name-form"} onSubmit={onFormSubmit}>
+                    <FormGroup
+                      fieldId="processor-name"
+                      validated={
+                        isNameValid
+                          ? ValidatedOptions.default
+                          : ValidatedOptions.error
+                      }
+                      helperTextInvalid={t(
+                        "processor.pleaseEnterAProcessorName"
+                      )}
+                      helperTextInvalidIcon={<ExclamationCircleIcon />}
+                    >
+                      <TextInput
+                        className="pf-c-form-control"
+                        id={"processor-name"}
+                        value={nameValue}
+                        type="text"
+                        onChange={onChangeInputValue}
+                        validated={
+                          isNameValid
+                            ? ValidatedOptions.default
+                            : ValidatedOptions.error
+                        }
+                        autoFocus={true}
+                      />
+                    </FormGroup>
+                  </Form>
+                </div>
+                <div className="pf-c-inline-edit__group pf-m-action-group pf-m-icon-group">
+                  <div className="pf-c-inline-edit__action pf-m-valid">
+                    <Button
+                      variant={"plain"}
+                      onClick={onDoneEditing}
+                      aria-label={t("processor.setName")}
+                      isDisabled={!isNameValid}
+                    >
+                      <CheckIcon />
+                    </Button>
+                  </div>
+                  <div className="pf-c-inline-edit__action">
+                    <Button
+                      variant={"plain"}
+                      onClick={onCancelEditing}
+                      aria-label={t("processor.cancelEdits")}
+                    >
+                      <TimesIcon />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <TextContent>
+              <Text component="h1">
+                <span>{name}</span>
+                <Button
+                  variant={"plain"}
+                  aria-label={t("processor.editName")}
+                  onClick={onStartEditing}
+                >
+                  <PencilAltIcon />
+                </Button>
+              </Text>
+            </TextContent>
+          )}
+        </SplitItem>
+        {showCreateAction && (
+          <SplitItem>
+            <Button onClick={onCreate}>{t("processor.deployProcessor")}</Button>
+          </SplitItem>
+        )}
+      </Split>
+    </PageSection>
+  );
+};
+
+export default ProcessorEditHeader;

--- a/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.tsx
+++ b/src/app/components/POCs/ProcessorEditHeader/ProcessorEditHeader.tsx
@@ -13,13 +13,14 @@ import {
   TextInput,
   ValidatedOptions,
 } from "@patternfly/react-core";
-import { useTranslation } from "@rhoas/app-services-ui-components";
 import {
   CheckIcon,
   ExclamationCircleIcon,
   PencilAltIcon,
   TimesIcon,
 } from "@patternfly/react-icons";
+import { useTranslation } from "@rhoas/app-services-ui-components";
+import "./ProcessorEditHeader.css";
 
 export interface ProcessorEditHeaderProps {
   name?: string;
@@ -79,10 +80,7 @@ const ProcessorEditHeader: FunctionComponent<ProcessorEditHeaderProps> = (
           {isEditing ? (
             <div className="pf-c-inline-edit pf-m-inline-editable">
               <div className="pf-c-inline-edit__group">
-                <div
-                  className="pf-c-inline-edit__input"
-                  style={{ maxWidth: 400 }}
-                >
+                <div className="pf-c-inline-edit__input processor-name-input">
                   <Form id={"processor-name-form"} onSubmit={onFormSubmit}>
                     <FormGroup
                       fieldId="processor-name"


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-1339

Initial implementation of the processor editing header.

PF doesn't provide a react component for inline editing, so I've used [their html code only](https://www.patternfly.org/v4/components/inline-edit).

I didn't add the actions dropdown because it's likely actions will not be available while creating/editing a processor. We can come back to this later if necessary.
