### PR TITLE
NO JIRA: Fix instability of Pagination and InstanceStatus Test

### DIFF
--- a/cypress/integration/instance/InstanceStatuses.ts
+++ b/cypress/integration/instance/InstanceStatuses.ts
@@ -19,6 +19,8 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
     beforeEach(() => {
       visitWithCookies("/");
       pageWasLoaded();
+      //The first load might be incorrect, I will wait till the table is updated
+      cy.wait(8000);
     });
 
     it("Accepted", () => {

--- a/cypress/integration/instance/Pagination.ts
+++ b/cypress/integration/instance/Pagination.ts
@@ -102,6 +102,7 @@ onlyOn(isEnvironmentType(EnvType.Mocked), () => {
       //Instance one is mocked to be ready.
       waitTillInstanceIsReady("Instance one");
       deletedInstanceNotExist(instanceTen);
+      waitTillInstanceIsReady("Instance one");
       cy.get(".pf-c-pagination__total-items >b:nth-of-type(2)").then(
         (count) => {
           let instanceCountAfterDelete = parseInt(count.text());

--- a/cypress/utils/Util.ts
+++ b/cypress/utils/Util.ts
@@ -48,7 +48,8 @@ export function pageWasLoaded() {
   //If you remove this line the next waiting rutine (loading-table) was succesful even if the page (DOM) was empty
   //Tests was randomly failing that an element was reattached to DOM.
   cy.get("#nav-toggle", { timeout: 30000 }).should("be.visible");
-  cy.ouiaId("loading-table", "PF4/Card").should("not.exist");
+  //The mocked / dev should contain Instance one in the ready state, check that this instance is displayed correctly (no skeleton)
+  waitTillInstanceIsReady("Instance one");
 }
 
 export function createInstance(newInstanceName: string, action?: string) {

--- a/cypress/utils/Util.ts
+++ b/cypress/utils/Util.ts
@@ -41,14 +41,11 @@ export function visitWithCookies(path: string) {
 
 /**
  * Wait that page is loaded correctly and there is no skeleton.
- * It means no ouiaId("loading-table", "PF4/Card")
  */
 export function pageWasLoaded() {
   //added waiting on any element to be clear that dom is not empty
-  //If you remove this line the next waiting rutine (loading-table) was succesful even if the page (DOM) was empty
-  //Tests was randomly failing that an element was reattached to DOM.
+  //If you remove this line the next waiting rutine (div[class="pf-c-skeleton"]) is valid: the page is empty => skeleton does not exist
   cy.get("#nav-toggle", { timeout: 30000 }).should("be.visible");
-  //The mocked / dev should contain Instance one in the ready state, check that this instance is displayed correctly (no skeleton)
   cy.get('div[class="pf-c-skeleton"]').should("not.exist");
 }
 

--- a/cypress/utils/Util.ts
+++ b/cypress/utils/Util.ts
@@ -49,7 +49,7 @@ export function pageWasLoaded() {
   //Tests was randomly failing that an element was reattached to DOM.
   cy.get("#nav-toggle", { timeout: 30000 }).should("be.visible");
   //The mocked / dev should contain Instance one in the ready state, check that this instance is displayed correctly (no skeleton)
-  waitTillInstanceIsReady("Instance one");
+  cy.get('div[class="pf-c-skeleton"]').should("not.exist");
 }
 
 export function createInstance(newInstanceName: string, action?: string) {


### PR DESCRIPTION
During the last month the execution of:

- [InstanceStatuses.ts](https://github.com/sjamboro/sandbox-ui/blob/nojira-fixinstability230124/cypress/integration/instance/InstanceStatuses.ts)
- [Pagination](https://github.com/sjamboro/sandbox-ui/blob/nojira-fixinstability230124/cypress/integration/instance/Pagination.ts)
started failing (randomly).

InstanceStatuses failure might be connected with this state:
![image](https://user-images.githubusercontent.com/1536609/214244178-40d19de0-6dd1-40ac-a64d-ff98854f7866.png)


I have added a wait rutine to the next update of the table.